### PR TITLE
Initial agnostic cluster reference implementation

### DIFF
--- a/ri/agnostic-aws/bootstrap/main.tf
+++ b/ri/agnostic-aws/bootstrap/main.tf
@@ -1,0 +1,11 @@
+module "bootstrap_instance" {
+  source = "../ec2_instance"
+  instance_type = var.instance_type
+  subnet_id = var.subnet_id
+  cluster_member_sg_id =var.cluster_member_sg_id
+  cluster_instance_profile_name = var.cluster_instance_profile_name
+  ami_id = var.ami_id
+  key_name = var.key_name
+  instance_kind = "bootstrap"
+  extra_user_data = "echo 'hello bootstrap' > /var/log/bootstrap.log.txt"
+}

--- a/ri/agnostic-aws/bootstrap/outputs.tf
+++ b/ri/agnostic-aws/bootstrap/outputs.tf
@@ -1,0 +1,3 @@
+output "bootstrap_instance_id" {
+  value = module.bootstrap_instance.instance_id
+}

--- a/ri/agnostic-aws/bootstrap/variables.tf
+++ b/ri/agnostic-aws/bootstrap/variables.tf
@@ -1,0 +1,6 @@
+variable "subnet_id" {}
+variable "instance_type" {}
+variable "ami_id" {}
+variable "cluster_member_sg_id" {}
+variable "cluster_instance_profile_name"  {}
+variable "key_name"  {}

--- a/ri/agnostic-aws/cluster_dns/main.tf
+++ b/ri/agnostic-aws/cluster_dns/main.tf
@@ -1,0 +1,73 @@
+data "aws_route53_zone" "cluster_zone" {
+  name = var.base_domain
+}
+
+resource "aws_route53_record" "api_record_a" {
+  zone_id = data.aws_route53_zone.cluster_zone.id
+  name    = "api.${var.cluster_name}.${var.base_domain}."
+  type    = "A"
+  alias {
+    name                   = var.api_lb_dns_name
+    zone_id                = var.api_lb_dns_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# TODO
+# resource "aws_route53_record" "api_record_ptr" {
+#  zone_id =  data.aws_route53_zone.cluster_zone.id
+#  name    = "${join(".", reverse(split(".", aws_route53_record.api_record_a.name)))}.in-addr.arpa."
+#  type    = "PTR"
+#  ttl     = 300
+
+#  records = [var.ptr_record_value]
+# }
+
+resource "aws_route53_record" "api_int_record_a" {
+  zone_id = data.aws_route53_zone.cluster_zone.id
+  name    = "api-int.${var.cluster_name}.${var.base_domain}."
+  type    = "A"
+  alias {
+    name                   = var.api_lb_dns_name
+    zone_id                = var.api_lb_dns_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# TODO: Review DNS Targets
+
+resource "aws_route53_record" "apps_record_a" {
+  zone_id = data.aws_route53_zone.cluster_zone.id
+  name    = "*.apps.${var.cluster_name}.${var.base_domain}."
+  type    = "A"
+  alias {
+    name                   = var.api_lb_dns_name
+    zone_id                = var.api_lb_dns_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "bootstrap_record_a" {
+  zone_id = data.aws_route53_zone.cluster_zone.id
+  name    = "bootstrap.${var.cluster_name}.${var.base_domain}."
+  type    = "A"
+  alias {
+    name                   = var.api_lb_dns_name
+    zone_id                = var.api_lb_dns_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "bootstrap_record_a" {
+  zone_id = data.aws_route53_zone.cluster_zone.id
+  name    = "bootstrap.${var.cluster_name}.${var.base_domain}."
+  type    = "A"
+  alias {
+    name                   = var.api_lb_dns_name
+    zone_id                = var.api_lb_dns_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# TODO: <master><n>.<cluster_name>.<base_domain>.
+# TODO: <worker><n>.<cluster_name>.<base_domain>.

--- a/ri/agnostic-aws/cluster_dns/variables.tf
+++ b/ri/agnostic-aws/cluster_dns/variables.tf
@@ -1,0 +1,4 @@
+variable "base_domain" {}
+variable "cluster_name" {}
+variable "api_lb_dns_name" {}
+variable "api_lb_dns_zone_id" {}

--- a/ri/agnostic-aws/cluster_lb/main.tf
+++ b/ri/agnostic-aws/cluster_lb/main.tf
@@ -1,0 +1,51 @@
+resource "aws_lb" "api_nlb" {
+  name               = "api-network-lb"
+  internal           = false
+  load_balancer_type = "network"
+
+  dynamic "subnet_mapping" {
+    for_each = var.subnet_ids
+    content {
+      subnet_id = subnet_mapping.value
+    }
+  }
+}
+
+resource "aws_lb_listener" "control_plane" {
+  count = length(var.control_plane_instances_ids)
+
+  load_balancer_arn = aws_lb.api_nlb.arn
+  port              = 6443
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.control_plane.arn
+  }
+}
+
+
+resource "aws_lb_target_group" "control_plane" {
+  name_prefix      = "ocpcp-"
+  port             = 6443
+  protocol         = "TCP"
+  target_type      = "instance"
+  vpc_id           = var.vpc_id
+  deregistration_delay = 30
+
+  health_check {
+    healthy_threshold   = 4
+    unhealthy_threshold = 2
+    interval            = 60
+    timeout             = 15
+    protocol            = "TCP"
+  }
+}
+
+# resource "aws_lb_target_group_attachment" "control_plane" {
+#  count = length(var.control_plane_instances_ids)
+#
+#  target_group_arn = aws_lb_target_group.control_plane.arn
+#  target_id        = var.control_plane_instances_ids[count.index]
+#  port             = 6443
+#}

--- a/ri/agnostic-aws/cluster_lb/outputs.tf
+++ b/ri/agnostic-aws/cluster_lb/outputs.tf
@@ -1,0 +1,12 @@
+output "api_lb_name" {
+  value = aws_lb.api_nlb.name
+}
+
+output "api_lb_dns_name" {
+  value = aws_lb.api_nlb.dns_name
+}
+
+output "api_lb_zone_id" {
+  value = aws_lb.api_nlb.zone_id
+}
+

--- a/ri/agnostic-aws/cluster_lb/variables.tf
+++ b/ri/agnostic-aws/cluster_lb/variables.tf
@@ -1,0 +1,8 @@
+variable "vpc_id" {}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "control_plane_instances_ids" {
+}

--- a/ri/agnostic-aws/control_plane/main.tf
+++ b/ri/agnostic-aws/control_plane/main.tf
@@ -1,0 +1,10 @@
+module "control_plane_instances" {
+  count = length(var.subnet_ids)
+  source = "../ec2_instance"
+  instance_type = var.instance_type
+  subnet_id = var.subnet_ids[count.index]
+  cluster_member_sg_id =var.cluster_member_sg_id
+  cluster_instance_profile_name = var.cluster_instance_profile_name
+  ami_id = var.ami_id
+  key_name = var.key_name
+}

--- a/ri/agnostic-aws/control_plane/outputs.tf
+++ b/ri/agnostic-aws/control_plane/outputs.tf
@@ -1,0 +1,6 @@
+output "control_plane_instance_ids" {
+  value = { for idx, instance in module.control_plane_instances :
+      "control_plane_${idx}"
+       => instance.instance_id }
+}
+

--- a/ri/agnostic-aws/control_plane/variables.tf
+++ b/ri/agnostic-aws/control_plane/variables.tf
@@ -1,0 +1,8 @@
+variable "subnet_ids" {
+    type = list(string)
+}
+variable "instance_type" {}
+variable "ami_id" {}
+variable "cluster_member_sg_id" {}
+variable "cluster_instance_profile_name"  {}
+variable "key_name"  {}

--- a/ri/agnostic-aws/ec2_instance/main.tf
+++ b/ri/agnostic-aws/ec2_instance/main.tf
@@ -1,0 +1,19 @@
+resource "aws_instance" "bootstrap_instance" {
+  ami           = var.ami_id
+  instance_type = var.instance_type
+  subnet_id     = var.subnet_id
+  security_groups = [var.cluster_member_sg_id]
+  iam_instance_profile = var.cluster_instance_profile_name
+  key_name = var.key_name
+  user_data              = <<EOF
+#!/bin/bash
+amazon-linux-extras install -y epel
+yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+systemctl enable amazon-ssm-agent
+systemctl start amazon-ssm-agent
+${var.extra_user_data}
+EOF
+  tags = {
+    Name = "opct-${var.instance_kind}"
+  }
+}

--- a/ri/agnostic-aws/ec2_instance/outputs.tf
+++ b/ri/agnostic-aws/ec2_instance/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_id" {
+  value = aws_instance.bootstrap_instance.id
+}

--- a/ri/agnostic-aws/ec2_instance/variables.tf
+++ b/ri/agnostic-aws/ec2_instance/variables.tf
@@ -1,0 +1,10 @@
+variable "subnet_id" {}
+variable "instance_type" {}
+variable "ami_id" {}
+variable "cluster_member_sg_id" {}
+variable "cluster_instance_profile_name"  {}
+variable "key_name"  {}
+variable "instance_kind" {
+  default = "instance"
+}
+variable "extra_user_data" {}

--- a/ri/agnostic-aws/main.tf
+++ b/ri/agnostic-aws/main.tf
@@ -1,0 +1,70 @@
+# tf apply -auto-approve
+provider "aws" {
+  region = var.aws_region
+}
+
+module "networking" {
+  source = "./networking"
+  aws_region = var.aws_region
+}
+
+module "security" {
+  source = "./security"
+  aws_region = var.aws_region
+  vpc_id = module.networking.vpc_id
+
+  depends_on = [ module.networking ]
+}
+
+
+module "bootstrap" {
+  source = "./bootstrap"
+  instance_type = var.instance_type
+  subnet_id = module.networking.public_subnet_ids[0]
+  cluster_member_sg_id = module.security.cluster_member_sg_id
+  cluster_instance_profile_name = module.security.cluster_instance_profile_name
+  ami_id = var.ami_mapping[var.aws_region][var.architecture]
+  key_name = module.security.key_name
+  depends_on = [ module.security ]
+}
+
+#module "control_plane" {
+#  source = "./control_plane"
+#  instance_type = var.instance_type
+#  subnet_ids = module.networking.public_subnet_ids
+#  cluster_member_sg_id = module.security.cluster_member_sg_id
+#  cluster_instance_profile_name = module.security.cluster_instance_profile_name
+#  ami_id = var.ami_mapping[var.aws_region][var.architecture]
+#  key_name = module.security.key_name
+#  depends_on = [ module.security ]
+#}
+#
+#module "workers" {
+#  source = "./workers"
+#  instance_type = var.instance_type
+#  subnet_id = module.networking.public_subnet_ids[0]
+#  cluster_member_sg_id = module.security.cluster_member_sg_id
+#  cluster_instance_profile_name = module.security.cluster_instance_profile_name
+#  ami_id = var.ami_mapping[var.aws_region][var.architecture]
+#  key_name = module.security.key_name
+#  depends_on = [ module.security ]
+#}
+#
+#module "cluster_lb" {
+#  source = "./cluster_lb"
+#  vpc_id = module.networking.vpc_id
+#  # TODO: Consider using private subnets
+#  subnet_ids = module.networking.public_subnet_ids
+#  control_plane_instances_ids = module.control_plane.control_plane_instance_ids
+#}
+#
+#module "cluster_dns" {
+#  source = "./cluster_dns"
+#  cluster_name        = var.cluster_name
+#  base_domain         = var.base_domain
+#  api_lb_dns_name     = module.cluster_lb.api_lb_dns_name
+#  api_lb_dns_zone_id  = module.cluster_lb.api_lb_zone_id
+#}
+#
+#
+#

--- a/ri/agnostic-aws/networking/main.tf
+++ b/ri/agnostic-aws/networking/main.tf
@@ -1,0 +1,116 @@
+
+resource "aws_vpc" "cluster_vpc" {
+  cidr_block = var.vpc_cidr_block
+  tags = {
+    Name = "cluster_vpc"
+  }
+}
+
+# Create three public subnets
+resource "aws_subnet" "public_subnet_1" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.public_subnet_cidr_blocks[0]
+  availability_zone = var.public_az_1
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "public_subnet_1"
+  }
+}
+
+resource "aws_subnet" "public_subnet_2" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.public_subnet_cidr_blocks[1]
+  availability_zone = var.public_az_2
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "public_subnet_2"
+  }
+}
+
+resource "aws_subnet" "public_subnet_3" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.public_subnet_cidr_blocks[2]
+  availability_zone = var.public_az_3
+  map_public_ip_on_launch = true
+  tags = {
+    Name = "public_subnet_3"
+  }
+}
+
+# Create three private subnets
+resource "aws_subnet" "private_subnet_1" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.private_subnet_cidr_blocks[0]
+  availability_zone = var.private_az_1
+  tags = {
+    Name = "private_subnet_1"
+  }
+}
+
+resource "aws_subnet" "private_subnet_2" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.private_subnet_cidr_blocks[1]
+  availability_zone = var.private_az_2
+  tags = {
+    Name = "private_subnet_2"
+  }
+}
+
+resource "aws_subnet" "private_subnet_3" {
+  vpc_id            = aws_vpc.cluster_vpc.id
+  cidr_block        = var.private_subnet_cidr_blocks[2]
+  availability_zone = var.private_az_3
+  tags = {
+    Name = "private_subnet_3"
+  }
+}
+
+# Create an internet gateway and attach it to the VPC
+resource "aws_internet_gateway" "cluster_igw" {
+  vpc_id = aws_vpc.cluster_vpc.id
+  tags = {
+    Name = "cluster_igw"
+  }
+}
+
+# Create a route table and associate the public subnets with it
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.cluster_vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.cluster_igw.id
+  }
+
+  tags = {
+    Name = "public_rt"
+  }
+}
+
+resource "aws_route_table_association" "public_subnet_association_1" {
+  subnet_id = aws_subnet.public_subnet_1.id
+  route_table_id = aws_route_table.public_rt.id
+
+  depends_on = [
+    aws_route_table.public_rt,
+  ]
+}
+
+resource "aws_route_table_association" "public_subnet_association_2" {
+  subnet_id = aws_subnet.public_subnet_2.id
+  route_table_id = aws_route_table.public_rt.id
+
+  depends_on = [
+    aws_route_table.public_rt,
+  ]
+}
+
+resource "aws_route_table_association" "public_subnet_association_3" {
+  subnet_id = aws_subnet.public_subnet_3.id
+  route_table_id = aws_route_table.public_rt.id
+
+  depends_on = [
+    aws_route_table.public_rt,
+  ]
+}
+

--- a/ri/agnostic-aws/networking/outputs.tf
+++ b/ri/agnostic-aws/networking/outputs.tf
@@ -1,0 +1,39 @@
+output "aws_region" {
+  value = var.aws_region
+}
+
+output "vpc_id" {
+  value = aws_vpc.cluster_vpc.id
+}
+
+output "public_subnet_ids" {
+  value = [
+    aws_subnet.public_subnet_1.id,
+    aws_subnet.public_subnet_2.id,
+    aws_subnet.public_subnet_3.id,
+  ]
+}
+
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.private_subnet_1.id,
+    aws_subnet.private_subnet_2.id,
+    aws_subnet.private_subnet_3.id,
+  ]
+}
+
+output "internet_gateway_id" {
+  value = aws_internet_gateway.cluster_igw.id
+}
+
+output "public_route_table_id" {
+  value = aws_route_table.public_rt.id
+}
+
+output "public_subnet_association_ids" {
+  value = [
+    aws_route_table_association.public_subnet_association_1.id,
+    aws_route_table_association.public_subnet_association_2.id,
+    aws_route_table_association.public_subnet_association_3.id,
+  ]
+}

--- a/ri/agnostic-aws/networking/variables.tf
+++ b/ri/agnostic-aws/networking/variables.tf
@@ -1,0 +1,39 @@
+variable "aws_region" {}
+
+variable "vpc_cidr_block" {
+  default = "10.0.0.0/16"
+}
+
+variable "public_az_1" {
+  default = "us-west-2a"
+}
+
+variable "public_az_2" {
+  default = "us-west-2b"
+}
+
+variable "public_az_3" {
+  default = "us-west-2c"
+}
+
+variable "private_az_1" {
+  default = "us-west-2a"
+}
+
+variable "private_az_2" {
+  default = "us-west-2b"
+}
+
+variable "private_az_3" {
+  default = "us-west-2c"
+}
+
+variable "public_subnet_cidr_blocks" {
+  type = list(string)
+  default = ["10.0.1.0/24", "10.0.3.0/24", "10.0.5.0/24"]
+}
+
+variable "private_subnet_cidr_blocks" {
+  type = list(string)
+  default = ["10.0.2.0/24", "10.0.4.0/24", "10.0.6.0/24"]
+}

--- a/ri/agnostic-aws/outputs.tf
+++ b/ri/agnostic-aws/outputs.tf
@@ -1,0 +1,46 @@
+output "vpc_id" {
+  value = module.networking.vpc_id
+}
+
+output "cluster_member_sg_id" {
+  value = module.security.cluster_member_sg_id
+}
+
+output "bootstrap_instance_id" {
+  value = module.bootstrap.bootstrap_instance_id
+}
+
+output "bootstrap_instance_url" {
+  value = "https://${var.aws_region}.console.aws.amazon.com/ec2/home?region=${var.aws_region}#InstanceDetails:instanceId=${module.bootstrap.bootstrap_instance_id}"
+}
+
+output "bootstrap_instance_ssm_url" {
+  value = "https://${var.aws_region}.console.aws.amazon.com/systems-manager/session-manager/${module.bootstrap.bootstrap_instance_id}?region=${var.aws_region}#"
+}
+
+/*
+output "control_plane_instance_ids" {
+  value = module.control_plane.control_plane_instance_ids
+}
+
+output "control_plane_instance_ssm_urls" {
+  value = { for idx, instance_id in module.control_plane.control_plane_instance_ids :
+    "control_plane_ssm_${idx}"
+      => "https://${var.aws_region}.console.aws.amazon.com/systems-manager/session-manager/${instance_id}?region=${var.aws_region}#" }
+}
+
+output "worker_instance_ids" {
+  value = module.control_plane.control_plane_instance_ids
+}
+
+output "worker_urls" {
+  value = { for idx, instance_id in module.control_plane.control_plane_instance_ids :
+  "worker_ssm_${idx}"
+  => "https://${var.aws_region}.console.aws.amazon.com/systems-manager/session-manager/${instance_id}?region=${var.aws_region}#" }
+}
+
+output "api_nlb_dns_name" {
+  value = module.cluster_lb.api_lb_dns_name
+}
+
+*/

--- a/ri/agnostic-aws/security/main.tf
+++ b/ri/agnostic-aws/security/main.tf
@@ -1,0 +1,239 @@
+# terraform apply -auto-approve
+
+resource "aws_security_group" "cluster_member_sg" {
+  name_prefix = "ssh_access_"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_security_group_rule" "allow_icmp" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "icmp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_ssh" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 22
+  to_port           = 22
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_http" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_https" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_udp_ntp" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 123
+  to_port           = 123
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+
+resource "aws_security_group_rule" "allow_metrics" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 1936
+  to_port           = 1936
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_host_services" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 9000
+  to_port           = 9999
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_k8s" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 10250
+  to_port           = 10259
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_sdn" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 10256
+  to_port           = 10256
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_k8s_node" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_udp_k8s_node" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 30000
+  to_port           = 32767
+  protocol          = "udp"
+  self              = true
+}
+
+
+resource "aws_security_group_rule" "allow_vxlan" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 4789
+  to_port           = 4789
+  protocol          = "udp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_vxlan_geneve" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 6081
+  to_port           = 6081
+  protocol          = "udp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_udp_host_services" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 9000
+  to_port           = 9999
+  protocol          = "udp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_udp_ipsec" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 500
+  to_port           = 500
+  protocol          = "udp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_udp_ipsec-nat" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 4500
+  to_port           = 4500
+  protocol          = "udp"
+  self              = true
+}
+
+
+
+resource "aws_security_group_rule" "allow_k8s_api" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 6443
+  to_port           = 6443
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_etcd" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = 2379
+  to_port           = 2380
+  protocol          = "tcp"
+  self              = true
+}
+
+
+resource "aws_security_group_rule" "allow_esp" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "ingress"
+  from_port         = -1
+  to_port           = -1
+  protocol          = "50"
+  self              = true
+}
+
+resource "aws_security_group_rule" "allow_outbound_tcp" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "allow_outbound_udp" {
+  security_group_id = aws_security_group.cluster_member_sg.id
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "udp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+#TODO: Set unique names
+resource "aws_iam_instance_profile" "cluster_instance_profile" {
+  name = "cluster-instance-profile"
+  role = aws_iam_role.cluster_role.id
+}
+
+resource "aws_iam_role" "cluster_role" {
+  name = "cluster-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy_attachment" "cluster_policy_attachment" {
+  name       = "example-policy-attachment"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  roles      = [aws_iam_role.cluster_role.name]
+}
+
+
+resource "tls_private_key" "cluster_key" {
+  algorithm   = "RSA"
+  rsa_bits    = 4096
+}
+
+resource "aws_key_pair" "cluster_key_pair" {
+  public_key = tls_private_key.cluster_key.public_key_openssh
+}
+

--- a/ri/agnostic-aws/security/outputs.tf
+++ b/ri/agnostic-aws/security/outputs.tf
@@ -1,0 +1,19 @@
+output "cluster_member_sg_id" {
+  value = aws_security_group.cluster_member_sg.id
+}
+
+output "cluster_instance_profile_name" {
+  value = aws_iam_instance_profile.cluster_instance_profile.name
+}
+
+output "public_key" {
+  value = aws_key_pair.cluster_key_pair.public_key
+}
+
+output "private_key" {
+  value = tls_private_key.cluster_key.private_key_pem
+}
+
+output "key_name" {
+  value = aws_key_pair.cluster_key_pair.key_name
+}

--- a/ri/agnostic-aws/security/variables.tf
+++ b/ri/agnostic-aws/security/variables.tf
@@ -1,0 +1,2 @@
+variable "aws_region" {}
+variable "vpc_id" {}

--- a/ri/agnostic-aws/variables.tf
+++ b/ri/agnostic-aws/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_region" {
+  default = "us-west-2"
+}
+
+variable "instance_type" {
+  default = "t3.xlarge"
+}
+
+variable "architecture" {
+  default = "x86_64"
+}
+
+// https://access.redhat.com/solutions/15356
+variable "ami_mapping" {
+  type = map(map(string))
+  default = {
+    "us-west-2" = {
+      "x86_64" = "ami-08970fb2e5767e3b8"
+      "arm64"  = "ami-0bb199dd39edd7d71"
+    }
+  }
+}
+
+
+variable "base_domain" {
+  default = "devcluster.openshift.com"
+}
+
+variable "cluster_name" {
+  default = "opct20230903"
+}

--- a/ri/agnostic-aws/workers/main.tf
+++ b/ri/agnostic-aws/workers/main.tf
@@ -1,0 +1,10 @@
+module "workers_instances" {
+  count = 2
+  source = "../ec2_instance"
+  instance_type = var.instance_type
+  subnet_id = var.subnet_id
+  cluster_member_sg_id =var.cluster_member_sg_id
+  cluster_instance_profile_name = var.cluster_instance_profile_name
+  ami_id = var.ami_id
+  key_name = var.key_name
+}

--- a/ri/agnostic-aws/workers/outputs.tf
+++ b/ri/agnostic-aws/workers/outputs.tf
@@ -1,0 +1,3 @@
+output "workers_instance_ids" {
+  value = { for idx, instance in module.workers_instances : "workers_${idx}" => instance.instance_id }
+}

--- a/ri/agnostic-aws/workers/variables.tf
+++ b/ri/agnostic-aws/workers/variables.tf
@@ -1,0 +1,6 @@
+variable "subnet_id" {}
+variable "instance_type" {}
+variable "ami_id" {}
+variable "cluster_member_sg_id" {}
+variable "cluster_instance_profile_name"  {}
+variable "key_name"  {}

--- a/ri/clients/ocp/latest-4.12/install.sh
+++ b/ri/clients/ocp/latest-4.12/install.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -ex
+
+OCP_VERSION="latest-4.12"
+URL_BASE="https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/$OCP_VERSION"
+echo "Downloading OCP [$OCP_VERSION] Clients from $URL_BASE"
+
+URL_INSTALLER="$URL_BASE/openshift-install-linux.tar.gz"
+URL_CLIENT="$URL_BASE/openshift-client-linux.tar.gz"
+URL_CCOCTL="$URL_BASE/ccoctl-linux.tar.gz"
+
+curl -s "$URL_INSTALLER" | tar -xz 'openshift-install'
+curl -s "$URL_CLIENT" | tar -xz 'oc'
+curl -s "$URL_CCOCTL" | tar -xz 'ccoctl'
+
+ls -l
+
+echo "export PATH=$PATH:$HOME/src/provider-certification-tool//clients/ocp/latest-4.12"
+echo "OCP [$OCP_VERSION] Clients installed"


### PR DESCRIPTION
This is the beginning of a reference implementation that employees and partners could use to set up an agnostic cluster (on AWS) in order to run the OPCT tests.
The goal is to make the whole process easier to execute and provide partners with a reference to start their own verification process.
This is just an initial take to collect your feedback and proceed until all requirements of agnostic install and OPCT checklist are met.