### PR TITLE
OPCT-304: cmd: adm parser-junit

### DIFF
--- a/docs/assets/output/_generate-outputs.sh
+++ b/docs/assets/output/_generate-outputs.sh
@@ -29,6 +29,7 @@ OUTPUT_DIR=${OUTPUT_OVERRIDE:-${DOC_ASSET_OUTPUT}}
 ./build/opct-linux-amd64 adm generate checks-docs --help > "${OUTPUT_DIR}"/opct-adm-generate-checks-docs.txt
 ./build/opct-linux-amd64 adm parse-etcd-logs --help > "${OUTPUT_DIR}"/opct-adm-parse-etcd-logs.txt
 ./build/opct-linux-amd64 adm parse-metrics --help > "${OUTPUT_DIR}"/opct-adm-parse-metrics.txt
+./build/opct-linux-amd64 adm parse-junit --help > "${OUTPUT_DIR}"/opct-adm-parse-junit.txt
 ./build/opct-linux-amd64 adm setup-node --help > "${OUTPUT_DIR}"/opct-adm-setup-node.txt
 
 

--- a/docs/assets/output/opct-adm-parse-junit.txt
+++ b/docs/assets/output/opct-adm-parse-junit.txt
@@ -1,0 +1,22 @@
+Administrative commands.
+
+Usage:
+  opct adm [flags]
+  opct adm [command]
+
+Available Commands:
+  baseline        Administrative commands to manipulate baseline results.
+  cleaner         Utility to apply pre-defined patches to existing result archive.
+  e2e-dedicated   Administrative commands for e2e-dedicated node configuration
+  generate        Generate administrative commands
+  parse-etcd-logs Parse ETCD logs.
+  parse-metrics   Process the metrics collected by OPCT and create a HTML report graph.
+
+Flags:
+  -h, --help   help for adm
+
+Global Flags:
+      --kubeconfig string   kubeconfig for target OpenShift cluster
+      --log-level string    logging level (default "info")
+
+Use "opct adm [command] --help" for more information about a command.

--- a/docs/opct/adm/parse-junit.md
+++ b/docs/opct/adm/parse-junit.md
@@ -1,0 +1,94 @@
+# opct adm parse-etcd-logs
+
+Extract the information from JUnit files to get insights from a test execution.
+
+## Options
+
+```txt
+--8<-- "docs/assets/output/opct-adm-parse-junit.txt"
+```
+
+## Usage
+
+!!! info "Added to OPCT in release: v0.6+"
+
+- Command: `opct adm parse-junit <path-to-junit-file>`
+
+Args:
+
+- `<path-to-junit-file>`: the path to the JUnit file.
+
+## Examples
+
+- Create the test list:
+
+```sh
+cat << EOF >./test-list.txt
+[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]"
+....
+EOF
+```
+
+- Run `openshift-tests` targetting the test list:
+
+> More information how to use [`openshift-tests`](./../../guides/features/running-e2e.md)
+
+```sh
+./openshift-tests run \
+    -f test-list.txt \
+    --monitor="etcd-log-analyzer" \
+    --junit-dir=./results
+```
+
+- Run the parser command:
+
+```bash
+$ ./build/opct-linux-amd64 adm parse-junit ./results/junit_e2e__20250313-192600.xml
+Summary:
+- File: ./results/junit_e2e__20250313-192600.xml
+- Total: 26
+- Pass: 23
+- Skipped: 0
+- Failures: 3
+
+JUnit Attributes:
+- XMLName: { testsuite}
+- Name: openshift-tests
+- Tests: 26
+- Skipped: 0
+- Failures: 3
+- Time: 1557
+- Property: {TestVersion 4.19.0-202502102307.p0.gc22aad1.assembly.stream.el9-c22aad1}
+
+#> Passed tests (23): 
+[sig-api-machinery] Watchers should observe an object deletion if it stops meeting the requirements of the selector [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+[sig-scheduling] SchedulerPredicates [Serial] validates that NodeAffinity is respected if not matching [Suite:openshift/conformance/serial] [Suite:k8s]
+[sig-scheduling] SchedulerPredicates [Serial] validates that NodeSelector is respected if not matching [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
+[sig-instrumentation] MetricsGrabber should grab all metrics slis from API server. [Suite:openshift/conformance/parallel] [Suite:k8s]
+[sig-scheduling] SchedulerPredicates [Serial] validates resource limits of pods that are allowed to run [Conformance] [Suite:openshift/conformance/serial/minimal] [Suite:k8s]
+[sig-scheduling] SchedulerPredicates [Serial] validates pod overhead is considered along with resource limits of pods that are allowed to run verify pod overhead is accounted for [Suite:openshift/conformance/serial] [Suite:k8s]
+[sig-cli] Kubectl client Kubectl diff should check if kubectl diff finds a difference for Deployments [Conformance] [Suite:openshift/conformance/parallel/minimal] [Suite:k8s]
+[sig-network][Feature:Router] The HAProxy router should enable openshift-monitoring to pull metrics [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-network][Feature:Router] The HAProxy router should expose prometheus metrics for a route [apigroup:route.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]
+[sig-auth][Feature:OpenShiftAuthorization][Serial] authorization TestAuthorizationResourceAccessReview should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/serial]
+[sig-cli] oc builds new-build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-network][Feature:Router] The HAProxy router should expose the profiling endpoints [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-api-machinery][Feature:APIServer] anonymous browsers should get a 403 from / [Suite:openshift/conformance/parallel]
+[sig-arch] Managed cluster should ensure platform components have system-* priority class associated [Suite:openshift/conformance/parallel]
+[sig-node][apigroup:config.openshift.io] CPU Partitioning cluster infrastructure should be configured correctly [Suite:openshift/conformance/parallel]
+[sig-network][Feature:Router] The HAProxy router should expose a health check on the metrics port [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-builds][Feature:Builds] oc new-app should succeed with an imagestream [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]
+[sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]
+[sig-cli] oc basics can get version information from API [Suite:openshift/conformance/parallel]
+[sig-auth][Feature:OAuthServer] well-known endpoint should be reachable [apigroup:route.openshift.io] [apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]
+Cluster should be stable after installation is complete
+Cluster should be stable before test is started
+
+#> Failed tests (3): 
+"[sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"
+"[sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial] [Suite:openshift/conformance/serial]"
+"[sig-network][Feature:tap] should create a pod with a tap interface [apigroup:k8s.cni.cncf.io] [Suite:openshift/conformance/parallel]"
+
+#> Skipped tests (0):
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
         - generate checks-docs: opct/adm/generate-checks-docs.md
         - parse-etcd-logs: opct/adm/parse-etcd-logs.md
         - parse-metrics: opct/adm/parse-metrics.md
+        - parse-junit: opct/adm/parse-junit.md
         - cleaner: opct/adm/cleaner.md
         - baseline: opct/adm/baseline.md
       - version: opct/version.md

--- a/pkg/api/junit.go
+++ b/pkg/api/junit.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Parse the XML data (JUnit created by openshift-tests)
+type TestStatus string
+
+const (
+	TestStatusPass    TestStatus = "pass"
+	TestStatusFail    TestStatus = "fail"
+	TestStatusSkipped TestStatus = "skipped"
+)
+
+type propSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+type Property struct {
+	Name  string `xml:"name,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type TestCase struct {
+	Name      string      `xml:"name,attr"`
+	Time      string      `xml:"time,attr"`
+	Failure   string      `xml:"failure"`
+	Skipped   propSkipped `xml:"skipped"`
+	SystemOut string      `xml:"system-out"`
+	Status    TestStatus
+}
+
+type TestSuite struct {
+	XMLName    xml.Name   `xml:"testsuite"`
+	Name       string     `xml:"name,attr"`
+	Tests      int        `xml:"tests,attr"`
+	Skipped    int        `xml:"skipped,attr"`
+	Failures   int        `xml:"failures,attr"`
+	Time       string     `xml:"time,attr"`
+	Property   Property   `xml:"property"`
+	Properties Property   `xml:"properties,omitempty"`
+	TestCases  []TestCase `xml:"testcase"`
+}
+
+type TestSuites struct {
+	Tests     int       `xml:"tests,attr"`
+	Disabled  int       `xml:"disabled,attr"`
+	Errors    int       `xml:"errors,attr"`
+	Failures  int       `xml:"failures,attr"`
+	Time      string    `xml:"time,attr"`
+	TestSuite TestSuite `xml:"testsuite"`
+}
+
+type JUnitCounter struct {
+	Total    int
+	Skipped  int
+	Failures int
+	Pass     int
+}
+
+type JUnitXMLParser struct {
+	XMLFile  string
+	Parsed   *TestSuite
+	Counters *JUnitCounter
+	Failures []string
+	Cases    []*TestCase
+}
+
+func NewJUnitXMLParser(xmlFile string) (*JUnitXMLParser, error) {
+	p := &JUnitXMLParser{
+		XMLFile:  xmlFile,
+		Parsed:   &TestSuite{},
+		Counters: &JUnitCounter{},
+		Cases:    []*TestCase{},
+	}
+	xmlData, err := os.ReadFile(xmlFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading XML file: %w", err)
+	}
+	if err := xml.Unmarshal(xmlData, p.Parsed); err != nil {
+		ts := &TestSuites{}
+		if err.Error() == "expected element type <testsuite> but have <testsuites>" {
+			log.Warnf("Found errors while processing default JUnit format, attempting new JUnit format for e2e...")
+			if err := xml.Unmarshal(xmlData, ts); err != nil {
+				return nil, fmt.Errorf("error parsing XML data with testsuites: %w", err)
+			}
+			p.Parsed = &ts.TestSuite
+		} else {
+			return nil, fmt.Errorf("error parsing XML data: %w", err)
+		}
+	}
+	// Iterate over the test cases
+	for _, testcase := range p.Parsed.TestCases {
+		// Create a new local copy of the testcase
+		tc := &testcase
+		p.Counters.Total++
+		if len(testcase.Skipped.Message) > 0 {
+			p.Counters.Skipped++
+			tc.Status = TestStatusSkipped
+			p.Cases = append(p.Cases, tc)
+			continue
+		}
+		if len(testcase.Failure) > 0 {
+			p.Counters.Failures++
+			p.Failures = append(p.Failures, fmt.Sprintf("\"%s\"", testcase.Name))
+			tc.Status = TestStatusFail
+			p.Cases = append(p.Cases, tc)
+			continue
+		}
+		tc.Status = TestStatusPass
+		p.Cases = append(p.Cases, tc)
+	}
+	p.Counters.Pass = p.Counters.Total - (p.Counters.Skipped + p.Counters.Failures)
+
+	return p, nil
+}

--- a/pkg/api/junit_test.go
+++ b/pkg/api/junit_test.go
@@ -1,0 +1,96 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewJUnitXMLParser(t *testing.T) {
+	// Create a fake JUnit XML file
+	xmlFile := createFakeJUnitXMLFileForOpenShiftTests()
+	defer removeFakeJUnitXMLFile(xmlFile)
+
+	parser, err := NewJUnitXMLParser(xmlFile)
+	assert.NoError(t, err)
+	assert.NotNil(t, parser)
+
+	// Assert the parsed test suite
+	assert.Equal(t, "openshift-tests", parser.Parsed.Name)
+	assert.Equal(t, 3, parser.Parsed.Tests)
+	assert.Equal(t, 1, parser.Parsed.Skipped)
+	assert.Equal(t, 1, parser.Parsed.Failures)
+	assert.Equal(t, "TestVersion", parser.Parsed.Property.Name)
+	assert.Equal(t, "4.14.0-202310201027.p0.g948001a.assembly.stream-948001a", parser.Parsed.Property.Value)
+
+	// Assert the parsed test cases
+	assert.Len(t, parser.Cases, 3)
+
+	// Assert the pass test case
+	assert.Equal(t, "test_case_name_1", parser.Cases[0].Name)
+	assert.Equal(t, "test_case_time_1", parser.Cases[0].Time)
+	assert.Equal(t, "test_case_system_out_1", parser.Cases[0].SystemOut)
+	assert.Equal(t, TestStatusPass, parser.Cases[0].Status)
+
+	// Assert the skipped test case
+	assert.Equal(t, "test_case_name_2", parser.Cases[1].Name)
+	assert.Equal(t, "test_case_time_2", parser.Cases[1].Time)
+	assert.Equal(t, "test_case_system_out_2", parser.Cases[1].SystemOut)
+	assert.Equal(t, TestStatusSkipped, parser.Cases[1].Status)
+	assert.Equal(t, "test_case_skipped_message_2", parser.Cases[1].Skipped.Message)
+
+	// Assert the failed test case
+	assert.Equal(t, "test_case_name_3", parser.Cases[2].Name)
+	assert.Equal(t, "test_case_time_3", parser.Cases[2].Time)
+	assert.Equal(t, "test_case_system_out_3", parser.Cases[2].SystemOut)
+	assert.Equal(t, TestStatusFail, parser.Cases[2].Status)
+	assert.Equal(t, "test_case_failure_3", parser.Cases[2].Failure)
+
+	// Assert the counters
+	assert.Equal(t, 3, parser.Counters.Total)
+	assert.Equal(t, 1, parser.Counters.Skipped)
+	assert.Equal(t, 1, parser.Counters.Failures)
+	assert.Equal(t, 1, parser.Counters.Pass)
+}
+
+func createFakeJUnitXMLFileForOpenShiftTests() string {
+	// Create a temporary file
+	file, err := os.CreateTemp("", "opct-e2e.xml")
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// Case 1: Write the fake JUnit XML content to the file
+	content := `<?xml version="1.0" encoding="UTF-8"?>
+	<testsuite name="openshift-tests" tests="3" skipped="1" failures="1" time="2568">
+    	<property name="TestVersion" value="4.14.0-202310201027.p0.g948001a.assembly.stream-948001a"></property>
+		<testcase name="test_case_name_1" time="test_case_time_1">
+			<system-out>test_case_system_out_1</system-out>
+		</testcase>
+		<testcase name="test_case_name_2" time="test_case_time_2">
+			<system-out>test_case_system_out_2</system-out>
+			<skipped message="test_case_skipped_message_2"/>
+		</testcase>
+		<testcase name="test_case_name_3" time="test_case_time_3">
+			<system-out>test_case_system_out_3</system-out>
+			<failure>test_case_failure_3</failure>
+		</testcase>
+	</testsuite>`
+	_, err = file.WriteString(content)
+	if err != nil {
+		panic(err)
+	}
+
+	// Return the file path
+	return file.Name()
+}
+
+func removeFakeJUnitXMLFile(file string) {
+	// Remove the temporary file
+	err := os.Remove(file)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/pkg/cmd/adm/parsejunit.go
+++ b/pkg/cmd/adm/parsejunit.go
@@ -1,0 +1,81 @@
+package adm
+
+import (
+	"fmt"
+	"strings"
+
+	opctapi "github.com/redhat-openshift-ecosystem/opct/pkg/api"
+	"github.com/spf13/cobra"
+)
+
+type parseJUnitInput struct {
+	skipFailed  bool
+	skipPassed  bool
+	skipSkipped bool
+}
+
+var parseJUnitArgs parseJUnitInput
+var parseJUnitCmd = &cobra.Command{
+	Use:     "parse-junit",
+	Example: "opct adm parse-junit",
+	Short:   "Parse a JUnit file generated from a e2e test.",
+	RunE:    parseJUnitRun,
+}
+
+func init() {
+	parseJUnitCmd.Flags().BoolVar(&parseJUnitArgs.skipFailed, "skip-failed", false, "Skip printing on stdout the failed test names.")
+	parseJUnitCmd.Flags().BoolVar(&parseJUnitArgs.skipPassed, "skip-passed", false, "Skip printing on stdout the passed test names.")
+	parseJUnitCmd.Flags().BoolVar(&parseJUnitArgs.skipSkipped, "skip-skipped", false, "Skip printing on stdout the skipped test names.")
+}
+
+func parseJUnitRun(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("please provide the path to the JUnit file")
+	}
+
+	junitFile := args[0]
+	parser, err := opctapi.NewJUnitXMLParser(junitFile)
+	if err != nil {
+		return fmt.Errorf("error parsing JUnit file: %v", err)
+	}
+
+	// Printing summary
+	fmt.Println("Summary:")
+	fmt.Printf("- File: %s\n", parser.XMLFile)
+	fmt.Printf("- Total: %d\n", parser.Counters.Total)
+	fmt.Printf("- Pass: %d\n", parser.Counters.Pass)
+	fmt.Printf("- Skipped: %d\n", parser.Counters.Skipped)
+	fmt.Printf("- Failures: %d\n", parser.Counters.Failures)
+	fmt.Println()
+	fmt.Println("JUnit Attributes:")
+	fmt.Printf("- XMLName: %v\n", parser.Parsed.XMLName)
+	fmt.Printf("- Name: %s\n", parser.Parsed.Name)
+	fmt.Printf("- Tests: %d\n", parser.Parsed.Tests)
+	fmt.Printf("- Skipped: %d\n", parser.Parsed.Skipped)
+	fmt.Printf("- Failures: %d\n", parser.Parsed.Failures)
+	fmt.Printf("- Time: %s\n", parser.Parsed.Time)
+	fmt.Printf("- Property: %v\n", parser.Parsed.Property)
+
+	// Passed tests
+	passed := []string{}
+	skipped := []string{}
+	for _, testcase := range parser.Cases {
+		if testcase.Status == opctapi.TestStatusPass {
+			passed = append(passed, testcase.Name)
+		}
+		if testcase.Status == opctapi.TestStatusSkipped {
+			skipped = append(skipped, testcase.Name)
+		}
+	}
+
+	if !parseJUnitArgs.skipPassed {
+		fmt.Printf("\n#> Passed tests (%d): \n%s\n", len(passed), strings.Join(passed, "\n"))
+	}
+	if !parseJUnitArgs.skipFailed {
+		fmt.Printf("\n#> Failed tests (%d): \n%s\n", len(parser.Failures), strings.Join(parser.Failures, "\n"))
+	}
+	if !parseJUnitArgs.skipSkipped {
+		fmt.Printf("\n#> Skipped tests (%d): \n%s\n", len(skipped), strings.Join(skipped, "\n"))
+	}
+	return nil
+}

--- a/pkg/cmd/adm/root.go
+++ b/pkg/cmd/adm/root.go
@@ -25,6 +25,7 @@ func init() {
 	admCmd.AddCommand(parseMetricsCmd)
 	admCmd.AddCommand(parseEtcdLogsCmd)
 	admCmd.AddCommand(cleanerCmd)
+	admCmd.AddCommand(parseJUnitCmd)
 	admCmd.AddCommand(baseline.NewCmdBaseline())
 	admCmd.AddCommand(generate.NewCommandGenerate())
 	admCmd.AddCommand(e2ed.NewCommandE2eDedicated())


### PR DESCRIPTION
Introduce a command to parse the JUnit files produced by e2e tests.

This is a helper when running `openshift-tests` manually, it will provide quickly access to the results without struggling with parsing the XML file with `xq`.

~~~
$ opct-devel adm parse-junit failed_tests_rerun/results/junit_e2e__20240827-213043.xml 
Summary:
- File: failed_tests_rerun/results/junit_e2e__20240827-213043.xml
- Total: 19
- Pass: 9
- Skipped: 0
- Failures: 10

JUnit Attributes:
- XMLName: { testsuite}
- Name: openshift-tests
- Tests: 19
- Skipped: 0
- Failures: 10
- Time: 2568
- Property: {TestVersion 4.14.0-202310201027.p0.g948001a.assembly.stream-948001a}

#> Passed tests (9): 
[sig-instrumentation] MetricsGrabber should grab all metrics slis from API server. [Suite:openshift/conformance/parallel] [Suite:k8s]
[sig-auth][Feature:UserAPI] users can manipulate groups [apigroup:user.openshift.io][apigroup:authorization.openshift.io][apigroup:project.openshift.io] [Suite:openshift/conformance/parallel]
[sig-cli] oc adm release extract image-references [Suite:openshift/conformance/parallel]
[sig-auth][Feature:OAuthServer] OAuth server has the correct token and certificate fallback semantics [apigroup:user.openshift.io] [Suite:openshift/conformance/parallel]
[sig-api-machinery][Feature:APIServer] anonymous browsers should get a 403 from / [Suite:openshift/conformance/parallel]
[sig-auth][Feature:OAuthServer] well-known endpoint should be reachable [apigroup:route.openshift.io] [apigroup:oauth.openshift.io] [Suite:openshift/conformance/parallel]
[sig-cli] oc basics can get version information from API [Suite:openshift/conformance/parallel]
[sig-arch] Managed cluster should only include cluster daemonsets that have maxUnavailable or maxSurge update of 10 percent or maxUnavailable of 33 percent [Suite:openshift/conformance/parallel]
[sig-arch] External binary usage

#> Failed tests (10): 
"[sig-instrumentation] Prometheus [apigroup:image.openshift.io] when installed on the cluster shouldn't report any alerts in firing state apart from Watchdog and AlertmanagerReceiversNotConfigured [Early][apigroup:config.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"
"[sig-network] Networking should provide Internet connection for containers [Feature:Networking-IPv4] [Skipped:Disconnected] [Skipped:Proxy] [Skipped:azure] [Suite:openshift/conformance/parallel] [Suite:k8s]"
"[sig-builds][Feature:Builds] oc new-app should succeed with a --name of 58 characters [apigroup:build.openshift.io] [Skipped:Disconnected] [Skipped:Proxy] [Suite:openshift/conformance/parallel]"
"[sig-builds][Feature:Builds] build can reference a cluster service with a build being created from new-build should be able to run a build that references a cluster service [apigroup:build.openshift.io] [Skipped:Disconnected] [Skipped:Proxy] [Suite:openshift/conformance/parallel]"
"[sig-auth][Feature:OpenShiftAuthorization][Serial] authorization TestAuthorizationResourceAccessReview should succeed [apigroup:authorization.openshift.io] [Suite:openshift/conformance/serial]"
"[sig-imageregistry][Feature:ImageInfo] Image info should display information about images [apigroup:image.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"
"[sig-cli] oc builds new-build [apigroup:build.openshift.io] [Skipped:Disconnected] [Suite:openshift/conformance/parallel]"
"[sig-network] services when running openshift ipv4 cluster ensures external ip policy is configured correctly on the cluster [apigroup:config.openshift.io] [Serial] [Suite:openshift/conformance/serial]"
"[sig-instrumentation][Late] OpenShift alerting rules [apigroup:image.openshift.io] should link to a valid URL if the runbook_url annotation is defined [Suite:openshift/conformance/parallel]"
"[sig-arch] External binary usage"

#> Skipped tests (0): 

~~~

It's useful when asking partners to replay tests / run `openshift-tests` manually. Example: https://issues.redhat.com/browse/OPCT-304