### PR TITLE
OCPBUGS-46532: clean data while collecting result archive

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -189,7 +189,6 @@ jobs:
         with:
           name: opct-linux-amd64
           path: /tmp/build/
-
       - name: "e2e adm generate checks-docs"
         env:
           OPCT: /tmp/build/opct-linux-amd64
@@ -206,3 +205,40 @@ jobs:
           # Enforce generated markdwn with the rules documentation page
           echo -e "\n\t#>> Fail if documentation not updated. Review and commit the changes to docs/review/rules.md"
           git diff --quiet docs/review/rules.md
+
+  e2e-cmd_adm-cleaner:
+    name: "e2e-cmd_adm-cleaner"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: opct-linux-amd64
+          path: /tmp/build/
+
+      - name: Preparing testdata
+        env:
+          ARTIFACT: fake-cleaner.tar.gz
+          CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
+          LOCAL_TEST_DATA: /tmp/artifact.tar.gz
+        run: |
+          TEST_URL=${TEST_DATA_URL}/${ARTIFACT}
+          echo "> Downloading sample artifact: ${TEST_URL}"
+          wget -qO ${LOCAL_TEST_DATA} "${TEST_URL}"
+
+          echo "> Setting exec permissions to OPCT:"
+          chmod u+x ${CUSTOM_BUILD_PATH}
+
+      - name: "e2e parse metrics: opct adm cleaner"
+        env:
+          CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
+          LOCAL_TEST_DATA: /tmp/artifact.tar.gz
+        run: |
+          ${CUSTOM_BUILD_PATH} adm cleaner \
+            --input ${LOCAL_TEST_DATA} \
+            --output /tmp/redacted.tar.gz
+          mkdir data
+          tar xfz /tmp/redacted.tar.gz -C data
+          # Prevent yaml-ci issues
+          MCC=machineconfiguration.openshift.io_v1_controllerconfigs.json
+          jq .items[].spec.internalRegistryPullSecret data/resources/cluster/${MCC}

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -1,0 +1,162 @@
+package cleaner
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"strings"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	log "github.com/sirupsen/logrus"
+)
+
+var patches = map[string]string{
+	"resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json": `[
+        {
+            "op": "replace",
+            "path": "/items/0/spec/internalRegistryPullSecret",
+            "value": "REDACTED"
+        }
+    ]`,
+}
+
+// ScanPatchTarGzipReaderFor scan for patches the artifact stream, returning
+// the cleaned artifact.
+func ScanPatchTarGzipReaderFor(r io.Reader) (resp io.Reader, size int, err error) {
+	log.Debug("Scanning the artifact for patches...")
+	size = 0
+
+	// Create a gzip reader
+	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, size, fmt.Errorf("unable to open gzip file: %w", err)
+	}
+	defer gzipReader.Close()
+
+	// Create a tar reader
+	tarReader := tar.NewReader(gzipReader)
+
+	// Create a buffer to store the updated tar.gz content
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	// Find and process the desired file
+	var desiredFile []byte
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, size, fmt.Errorf("unable to process file in archive: %w", err)
+		}
+
+		// Processing pre-defined patches, including recursively archives inside base.
+		if _, ok := patches[header.Name]; ok {
+			// Once the pre-defined/hardcoded patch matches with file stream, apply
+			// the path according to the extension. Currently only JSON patches
+			// are supported.
+			log.Debugf("Patch pattern matched for: %s", header.Name)
+			if strings.HasSuffix(header.Name, ".json") {
+				var patchedFile []byte
+				desiredFile, err = io.ReadAll(tarReader)
+				if err != nil {
+					log.Errorf("unable to read file in archive: %v", err)
+					return nil, size, fmt.Errorf("unable to read file in archive: %w", err)
+				}
+
+				// Apply JSON patch to the file
+				patchedFile, err = applyJSONPatch(header.Name, desiredFile)
+				if err != nil {
+					log.Errorf("unable to apply patch to file %s: %v", header.Name, err)
+					return nil, size, fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
+				}
+
+				// Update the file size in the header
+				header.Size = int64(len(patchedFile))
+				log.Debugf("Patched %d bytes", header.Size)
+
+				// Write the updated file to stream.
+				if err := tarWriter.WriteHeader(header); err != nil {
+					log.Errorf("unable to write file header to new archive: %v", err)
+					return nil, size, fmt.Errorf("unable to write file header to new archive: %w", err)
+				}
+				if _, err := tarWriter.Write(patchedFile); err != nil {
+					log.Errorf("unable to write file data to new archive: %v", err)
+					return nil, size, fmt.Errorf("unable to write file data to new archive: %w", err)
+				}
+			} else {
+				log.Debugf("unknown extension, skipping patch for file %s", header.Name)
+			}
+
+		} else if strings.HasSuffix(header.Name, ".tar.gz") {
+			// recursively scan for .tar.gz files rewriting it back to the original archive.
+			// by default sonobuoy writes a base archive, and the result(s) will be inside of
+			// the base. So it is required to recursively scan archives to find required, hardcoded,
+			// patches.
+			log.Debugf("Scanning tarball archive: %s", header.Name)
+			resp, size, err = ScanPatchTarGzipReaderFor(tarReader)
+			if err != nil {
+				return nil, size, fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
+			}
+
+			// Update the file size in the header
+			header.Size = int64(size)
+
+			// Write the updated header and file content
+			buf := new(bytes.Buffer)
+			_, err := io.Copy(buf, resp)
+			if err != nil {
+				return nil, size, err
+			}
+
+			// write archive back to stream.
+			if err := tarWriter.WriteHeader(header); err != nil {
+				log.Errorf("unable to write file header to new archive: %v", err)
+				return nil, size, fmt.Errorf("unable to write file header to new archive: %w", err)
+			}
+			if _, err := tarWriter.Write(buf.Bytes()); err != nil {
+				log.Errorf("unable to write file data to new archive: %v", err)
+				return nil, size, fmt.Errorf("unable to write file data to new archive: %w", err)
+			}
+		} else {
+			// Copy other files as-is
+			if err := tarWriter.WriteHeader(header); err != nil {
+				return nil, size, fmt.Errorf("error streaming file header to new archive: %w", err)
+			}
+			if _, err := io.Copy(tarWriter, tarReader); err != nil {
+				return nil, size, fmt.Errorf("error streaming file data to new archive: %w", err)
+			}
+		}
+	}
+
+	// Close the writers
+	if err := tarWriter.Close(); err != nil {
+		return nil, size, fmt.Errorf("closing tarball: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, size, fmt.Errorf("closing gzip: %w", err)
+	}
+
+	// Return the updated tar.gz content as an io.Reader
+	size = len(buf.Bytes())
+	return bytes.NewReader(buf.Bytes()), size, nil
+}
+
+// applyJSONPatch apply hard coded patches to stream, returning the cleaned file.
+func applyJSONPatch(filepath string, data []byte) ([]byte, error) {
+	patch, err := jsonpatch.DecodePatch([]byte(patches[filepath]))
+	if err != nil {
+		return nil, fmt.Errorf("decoding patch: %w", err)
+	}
+
+	modified, err := patch.Apply(data)
+	if err != nil {
+		return nil, fmt.Errorf("applying patch: %w", err)
+	}
+
+	return modified, nil
+}

--- a/internal/cleaner/cleaner_test.go
+++ b/internal/cleaner/cleaner_test.go
@@ -1,0 +1,162 @@
+package cleaner
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestTarGz(files map[string]string) ([]byte, error) {
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	for name, content := range files {
+		header := &tar.Header{
+			Name: name,
+			Size: int64(len(content)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return nil, err
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		return nil, err
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+func TestScanPatchTarGzipReaderFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		files         map[string]string
+		expectedFiles map[string]string
+		expectError   bool
+	}{
+		{
+			name: "patch JSON file",
+			files: map[string]string{
+				"resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json": `{"items":[{"spec":{"internalRegistryPullSecret":"SECRET"}}]}`,
+			},
+			expectedFiles: map[string]string{
+				"resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json": `{"items":[{"spec":{"internalRegistryPullSecret":"REDACTED"}}]}`,
+			},
+			expectError: false,
+		},
+		{
+			name: "no patch needed",
+			files: map[string]string{
+				"some/other/file.txt": "This is a test file.",
+			},
+			expectedFiles: map[string]string{
+				"some/other/file.txt": "This is a test file.",
+			},
+			expectError: false,
+		},
+		// {
+		// 	name: "invalid gzip",
+		// 	files: map[string]string{
+		// 		"invalid.gz": "This is not a valid gzip file.",
+		// 	},
+		// 	expectedFiles: nil,
+		// 	expectError:   true,
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tarGzData, err := createTestTarGz(tt.files)
+			assert.NoError(t, err)
+
+			reader := bytes.NewReader(tarGzData)
+			resp, size, err := ScanPatchTarGzipReaderFor(reader)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Greater(t, size, 0)
+
+			// Read the response tar.gz
+			gzipReader, err := gzip.NewReader(resp)
+			assert.NoError(t, err)
+			defer gzipReader.Close()
+
+			tarReader := tar.NewReader(gzipReader)
+			for {
+				header, err := tarReader.Next()
+				if err == io.EOF {
+					break
+				}
+				assert.NoError(t, err)
+
+				expectedContent, ok := tt.expectedFiles[header.Name]
+				assert.True(t, ok)
+
+				content, err := io.ReadAll(tarReader)
+				assert.NoError(t, err)
+				assert.Equal(t, expectedContent, string(content))
+			}
+		})
+	}
+}
+
+func TestApplyJSONPatch(t *testing.T) {
+	tests := []struct {
+		name        string
+		filepath    string
+		data        []byte
+		expected    []byte
+		expectError bool
+	}{
+		{
+			name:     "valid patch",
+			filepath: "resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json",
+			data:     []byte(`{"items":[{"spec":{"internalRegistryPullSecret":"SECRET"}}]}`),
+			expected: []byte(`{"items":[{"spec":{"internalRegistryPullSecret":"REDACTED"}}]}`),
+		},
+		{
+			name:        "invalid patch",
+			filepath:    "resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json",
+			data:        []byte(`invalid json`),
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "no patch available",
+			filepath:    "nonexistent/file.json",
+			data:        []byte(`{"key":"value"}`),
+			expected:    nil,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := applyJSONPatch(tt.filepath, tt.data)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/cmd/adm/cleaner.go
+++ b/pkg/cmd/adm/cleaner.go
@@ -1,0 +1,79 @@
+package adm
+
+import (
+	"bufio"
+	"io"
+	"os"
+
+	"github.com/redhat-openshift-ecosystem/provider-certification-tool/internal/cleaner"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+type cleanerArguments struct {
+	input  string
+	output string
+}
+
+var cleanerArgs cleanerArguments
+var cleanerCmd = &cobra.Command{
+	Use:     "cleaner",
+	Example: "opct adm cleaner --input ./results.tar.gz --output ./results-cleaned.tar.gz",
+	Short:   "Utility to apply pre-defined patches to existing result archive.",
+	Run:     cleanerRun,
+}
+
+func init() {
+	cleanerCmd.Flags().StringVar(&cleanerArgs.input, "input", "", "Input archive file. Example: ./opct-xyz.tar.gz")
+	cleanerCmd.Flags().StringVar(&cleanerArgs.output, "output", "", "Output archive file. Example: ./opct-cleaned.tar.gz")
+}
+
+func cleanerRun(cmd *cobra.Command, args []string) {
+
+	if cleanerArgs.input == "" {
+		log.Error("missing argumet --input <archive.tar.gz>")
+		os.Exit(1)
+	}
+
+	if cleanerArgs.output == "" {
+		log.Error("missing argumet --output <new-archive.tar.gz>")
+		os.Exit(1)
+	}
+
+	log.Infof("Starting artifact cleaner for %s", cleanerArgs.input)
+
+	fin, err := os.Open(cleanerArgs.input)
+	if err != nil {
+		panic(err)
+	}
+
+	// close fi on exit and check for its returned error
+	defer func() {
+		if err := fin.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	r := bufio.NewReader(fin)
+
+	// scanning for sensitive data
+	cleaned, _, err := cleaner.ScanPatchTarGzipReaderFor(r)
+	if err != nil {
+		panic(err)
+	}
+
+	// Create a new file
+	file, err := os.Create(cleanerArgs.output)
+	if err != nil {
+		panic(err)
+	}
+	defer file.Close()
+
+	// Write the cleaned data to the file
+	_, err = io.Copy(file, cleaned)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Infof("Data successfully written to %s", cleanerArgs.output)
+}

--- a/pkg/cmd/adm/root.go
+++ b/pkg/cmd/adm/root.go
@@ -24,6 +24,7 @@ func init() {
 	admCmd.AddCommand(parseMetricsCmd)
 	admCmd.AddCommand(parseEtcdLogsCmd)
 	admCmd.AddCommand(setupNodeCmd)
+	admCmd.AddCommand(cleanerCmd)
 	admCmd.AddCommand(baseline.NewCmdBaseline())
 	admCmd.AddCommand(generate.NewCommandGenerate())
 }


### PR DESCRIPTION
[OCPBUGS-46532](https://issues.redhat.com/browse/OCPBUGS-46532)

Plugin ref https://issues.redhat.com/browse/OCPBUGS-46369
https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/68

This PR introduce a cleaner engine to remove predefined, unexpected, data from artifacts on client side to prevent exposing it to shareable/public artifacts.