### PR TITLE
OPCT-000: Bump to v0.5.1 to address bug fixes

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,9 +19,9 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
-	PluginsImage                   = "plugin-openshift-tests:v0.5.0"
-	CollectorImage                 = "plugin-artifacts-collector:v0.5.0"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.0"
+	PluginsImage                   = "plugin-openshift-tests:v0.5.1"
+	CollectorImage                 = "plugin-artifacts-collector:v0.5.1"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.1"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 )
 


### PR DESCRIPTION
Blocked by:

- https://github.com/redhat-openshift-ecosystem/opct/pull/130
- https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/68
- https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/69
- https://github.com/redhat-openshift-ecosystem/opct/pull/128
- https://github.com/redhat-openshift-ecosystem/opct/pull/129
- https://github.com/redhat-openshift-ecosystem/opct/pull/134