### PR TITLE
OPCT-311: fix(web-ui) - rule hyperlink must use rendered by docs

### DIFF
--- a/internal/report/slo.go
+++ b/internal/report/slo.go
@@ -1179,7 +1179,7 @@ and check the logs for errors.`,
 	// Create docs reference when ID is set
 	for c := range checkSum.Checks {
 		if checkSum.Checks[c].ID != CheckIdEmptyValue {
-			checkSum.Checks[c].Documentation = fmt.Sprintf("%s/#%s", checkSum.baseURL, checkSum.Checks[c].ID)
+			checkSum.Checks[c].Documentation = fmt.Sprintf("%s/#%s", checkSum.baseURL, strings.ToLower(checkSum.Checks[c].ID))
 		}
 	}
 	return checkSum


### PR DESCRIPTION
Fix documentation hyperlink to force the lower alphabetical values on rendered markdown pages - references/sections on https://redhat-openshift-ecosystem.github.io/opct/review/rules

This bug affects only report Web UI which points each SLO/Rule directly to the OPCT documentations:

![Screenshot from 2024-12-28 23-17-02](https://github.com/user-attachments/assets/2e2e701d-22b6-4010-bd42-11f6e8048b85)


https://issues.redhat.com/browse/OPCT-311