### PR TITLE
OPCT-335: bump to fix CI step for deprecation issue when deploy GH Pages

### DIFF
--- a/.github/workflows/static-website.yml
+++ b/.github/workflows/static-website.yml
@@ -45,13 +45,13 @@ jobs:
           make build-docs
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: './site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Bump steps used to deploy Github Pages to prevent deprecation of dependencies:
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

https://github.com/redhat-openshift-ecosystem/opct/actions/runs/13423181320/job/37551738748 https://issues.redhat.com/browse/OPCT-335