### PR TITLE
OPCT-263: docs: move requirements to docs/ path

### DIFF
--- a/.github/workflows/static-website.yml
+++ b/.github/workflows/static-website.yml
@@ -9,7 +9,6 @@ on:
     paths:
       - 'mkdocs.yml'
       - 'docs/**'
-      - 'hack/docs-requirements.txt'
 
   workflow_dispatch:
 
@@ -41,7 +40,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y python3-pip graphviz
-          pip3 install -r hack/docs-requirements.txt
+          pip3 install -r docs/requirements.txt
           make build-docs
 
       - name: Setup Pages

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-openshift-provider-cert-*
-opct-*
 kubeconfig
 .idea/
 

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,13 @@ vet:
 clean:
 	rm -rvf ./build/ ./openshift-provider-cert-* ./opct-*
 
-# For dependencies, see:
+
+#
+# Documentation
+#
+# See also:
 # .github/workflows/static-website.yml
-# hack/docs-requirements.txt
+# docs/requirements.txt
 
 .PHONY: build-changelog
 build-changelog:
@@ -106,6 +110,9 @@ build-changelog:
 build-docs: build-changelog
 	mkdocs build --site-dir ./site
 
+#
+# Mirror Sonobuoy aggregator server
+#
 .PHONY: image-mirror-sonobuoy
 image-mirror-sonobuoy:
 	./hack/image-mirror-sonobuoy/mirror.sh

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
-mkdocs==1.3.1
+mkdocs==1.6.1
 mkdocs-material
 mkdocs-mermaid2-plugin
 
 # Require graphviz
 mkdocs-diagrams
+
+# required to include markdown
+pymdown-extensions


### PR DESCRIPTION
**What this PR does / why we need it**:

Nit: move the requirements.txt, which handles mkdocs build dependencies, to the docs directory.

_Isolating changes from https://github.com/redhat-openshift-ecosystem/opct/pull/124_

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/OPCT-263

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
