### PR TITLE
SPLAT-2030: fixes: bump plugins to v0.5.2 fixing security alerts

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,9 +19,9 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
-	PluginsImage                   = "plugin-openshift-tests:v0.5.1"
-	CollectorImage                 = "plugin-artifacts-collector:v0.5.1"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.1"
+	PluginsImage                   = "plugin-openshift-tests:v0.5.2"
+	CollectorImage                 = "plugin-artifacts-collector:v0.5.2"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.2"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Update plugins release fixing security dependencies.


**Which issue(s) this PR fixes** :

https://issues.redhat.com/browse/SPLAT-2030
https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/actions/runs/13638099271
https://quay.io/repository/opct/plugin-openshift-tests?tab=tags
https://quay.io/repository/opct/plugin-artifacts-collector?tab=tags
https://quay.io/repository/opct/must-gather-monitoring?tab=tags

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
