### PR TITLE
OPCT-2030: mirror aggregator server/sonobuoy img v0.57.3

### DIFF
--- a/hack/image-mirror-sonobuoy/mirror.sh
+++ b/hack/image-mirror-sonobuoy/mirror.sh
@@ -6,7 +6,7 @@ set -o pipefail
 set -o nounset
 set -o errexit
 
-export SONOBUOY_VERSION=${SONOBUOY_VERSION:-v0.57.1}
+export SONOBUOY_VERSION=${SONOBUOY_VERSION:-v0.57.3}
 export SONOBUOY_REPO=docker.io/sonobuoy/sonobuoy
 export MIRROR_REPO=${MIRROR_REPO:-quay.io/opct/sonobuoy}
 export PLATFORM_IMAGES=""


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the aggregator server mirror config to v0.57.3 to get the changes in #144, then:
`make image-mirror-sonobuoy`

And check the mirrored images to OPCT registry: https://quay.io/repository/opct/sonobuoy?tab=tags

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/SPLAT-2030

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
