### PR TITLE
NO-JIRA: CI - added step to force kind label in a PR

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,20 @@
+---
+name: Pull Request Check
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # https://github.com/marketplace/actions/require-labels
+      - uses: mheap/github-action-required-labels@v5
+        with:
+          message: "This PR is being prevented from merging because you are missing the kind label: kind/.*"
+          mode: exactly
+          count: 1
+          labels: "kind/.*"
+          use_regex: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure the `kind/?` label has been added to the pull requests to be classified when generating a new release. It may prevent the dev to backfill pull requests, or having unclassified PRs as the following example: 

https://github.com/redhat-openshift-ecosystem/opct/releases/tag/v0.5.2

**Which issue(s) this PR fixes** 

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
