### PR TITLE
OPCT-332: added a controller to mutate e2e pods failed to schedule

### DIFF
--- a/docs/devel/guide.md
+++ b/docs/devel/guide.md
@@ -228,3 +228,39 @@ mkdocs serve
 ```
 
 Then you will be able to access the docs locally on the address: http://127.0.0.1:8000/
+
+
+## e2e-dedicated controller
+
+The e2e-dedicated controller is used to watch pods failing
+to schedule and apply tolerations to allow scheduling in
+the OPCT dedicated node, preventing false positives caused
+by the required OPCT environment (dedicated worker node).
+
+### Checking Logs in a Live Cluster
+
+You can check the logs in a live cluster using the following command:
+
+```sh
+oc logs -n opct -l app=opct-dedicated-e2e-controller -f
+```
+
+### Inspecting the Logs in the Archive File
+
+Alternatively you can inspect the controller logs from the archive
+collected in the artifacts collector step:
+
+```sh
+mkdir results-raw results-must-gather
+result_file=opct_202503132124_1899a26c-1564-4eab-b51a-2a39ca6caee4.tar.gz
+mustgather_file=results-raw/plugins/99-openshift-artifacts-collector/results/global/artifacts_must-gather.tar.xz
+
+# Extract the raw results
+tar xfz ${result_file} -C results-raw
+
+# Extracts the must-gather
+tar xfJ ${mustgather_file} -C results-must-gather/
+
+# Inspect the logs
+less results-must-gather/must-gather-opct/inspect-opct/namespaces/opct/pods/opct-dedicated-e2e-controller-*/controller/controller/logs/current.log
+```

--- a/pkg/cmd/adm/e2ed/controller.go
+++ b/pkg/cmd/adm/e2ed/controller.go
@@ -1,0 +1,242 @@
+package e2ed
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	types "github.com/redhat-openshift-ecosystem/opct/pkg"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
+)
+
+// newCmdE2eDedicatedController returns a new cobra.Command for starting the e2e-dedicated controller.
+// The controller watches all pods failing to schedule due to dedicated node configuration, specifically
+// for OPCT, which requires a toleration configuration in the pod spec. Failed pods will be mutated to
+// use the required toleration, preventing false-positive failures.
+func newCmdE2eDedicatedController() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "controller",
+		Short: "Start the e2e-dedicated controller.",
+		Long: `Start the e2e-dedicated controller to watch all pods failing to schedule due the
+		dedicated node configuration, specifically for OPCT, which requires a toleration configuration
+		in the pod spec.
+		Failed pods will be mutated to use the required toleration, preventing false-positive failures.`,
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		controllerRun()
+	}
+
+	return cmd
+}
+
+type podMutateStatus struct {
+	Successed uint64
+	Failed    uint64
+	Skipped   uint64
+}
+
+var (
+	podCounters      = make(map[string]*podMutateStatus)
+	podCountersMutex sync.Mutex
+)
+
+// getPodKey constructs a unique key for a pod using its namespace and name.
+func getPodKey(namespace, podName string) string {
+	return fmt.Sprintf("%s/%s", namespace, podName)
+}
+
+// ensureCounter checks if a counter exists for the given pod key and initializes it if not.
+func ensureCounter(podKey string) {
+	podCountersMutex.Lock()
+	defer podCountersMutex.Unlock()
+	if _, ok := podCounters[podKey]; !ok {
+		podCounters[podKey] = &podMutateStatus{}
+	}
+}
+
+func showCounter(podKey string) {
+	pk := podCounters[podKey]
+	log.Debugf("Metrics counter for %s: success(%d) skipped(%d) failed(%d)", podKey, pk.Successed, pk.Skipped, pk.Failed)
+}
+
+// incCounterFailure increments the failure counter for the given pod key.
+func incCounterFailure(podKey string) {
+	ensureCounter(podKey)
+	podCountersMutex.Lock()
+	podCounters[podKey].Failed += 1
+	podCountersMutex.Unlock()
+	showCounter(podKey)
+}
+
+// incCounterSkipped increments the skipped counter for the given pod key.
+func incCounterSkipped(podKey string) {
+	ensureCounter(podKey)
+	podCountersMutex.Lock()
+	podCounters[podKey].Skipped += 1
+	podCountersMutex.Unlock()
+	showCounter(podKey)
+}
+
+// incCounterSuccess increments the success counter for the given pod key.
+func incCounterSuccess(podKey string) {
+	ensureCounter(podKey)
+	podCountersMutex.Lock()
+	podCounters[podKey].Successed += 1
+	podCountersMutex.Unlock()
+	showCounter(podKey)
+}
+
+// showCounters prints the current counters for all pods.
+func showCounters(stop chan struct{}) {
+	previousTotal := 0
+	backoff := 10 * time.Second
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+			// Show summary of total pods changed for this controller.
+			failed := 0
+			skipped := 0
+			successed := 0
+			for podKey := range podCounters {
+				failed += int(podCounters[podKey].Failed)
+				skipped += int(podCounters[podKey].Skipped)
+				successed += int(podCounters[podKey].Successed)
+			}
+			// show summary with backoff to prevent many messages.
+			if previousTotal != len(podCounters) {
+				log.Printf("Metrics summary: Total pods changed: %d. successed(%d) skipped(%d) failed(%d)", len(podCounters), successed, skipped, failed)
+				previousTotal = len(podCounters)
+				time.Sleep(1 * time.Second)
+				continue
+			}
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > 2*time.Minute {
+				backoff = 2 * time.Minute
+				log.Printf("No change in metrics in the last 2 minutes.")
+			}
+		}
+
+	}
+}
+
+// controllerRun starts the dedicated-e2e controller which watches for pods failing to schedule
+// in the e2e namespaces and mutates them to include the required toleration.
+func controllerRun() {
+	log.Info("Starting the e2e-dedicated controller...")
+
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		log.Fatalf("Failed to get in-cluster config: %v. Ensure the KUBECONFIG environment variable is set or config is in the path:\n", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		log.Fatalf("Failed to create clientset: %v\n", err)
+	}
+
+	log.Info("Creating the informer to watch pods failed to schedule in e2e namespaces...")
+
+	// Create the informer to watch pods every one second, then mutate when updated. The mutation
+	// will add the required toleration.
+	_, controller := cache.NewInformerWithOptions(cache.InformerOptions{
+		ListerWatcher: cache.NewListWatchFromClient(
+			clientset.CoreV1().RESTClient(),
+			"pods",
+			corev1.NamespaceAll,
+			fields.Everything(),
+		),
+		ObjectType: &corev1.Pod{},
+		Handler: cache.ResourceEventHandlerDetailedFuncs{
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				newPod := newObj.(*corev1.Pod)
+				// ensure only e2e and opct (for tests) will be changed
+				if strings.HasPrefix(newPod.Namespace, "e2e-") || strings.HasPrefix(newPod.Namespace, "opct") {
+					for _, condition := range newPod.Status.Conditions {
+						// act only when the pod failed to schedule due the opct environment: one random worker node has taints preventing scheduling the node.
+						if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionFalse && condition.Reason == corev1.PodReasonUnschedulable {
+							handleFailedScheduling(clientset, newPod)
+						}
+					}
+				}
+			},
+		},
+		ResyncPeriod: 1 * time.Second,
+	})
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go controller.Run(stop)
+	go showCounters(stop)
+
+	select {}
+}
+
+// handleFailedScheduling is the update informer function handler to mutate the pod object adding the
+// required tolerations, when not exists. Informer function handlers can't return errors,
+// when operation fails, it will be logged in the default log handler.
+func handleFailedScheduling(clientset *kubernetes.Clientset, pod *corev1.Pod) {
+	podKey := getPodKey(pod.Namespace, pod.Name)
+	skipped := false
+	log.Debugf("[%s] starting the handler for failed scheduling pods", podKey)
+
+	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pod, err := clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			// Update functions can't return errors
+			log.Errorf("[%s] failed to get the pod by name: %v", podKey, err)
+			return nil
+		}
+
+		// add tolerations only if not yet applied to the node.
+		hasToleration := false
+		for _, toleration := range pod.Spec.Tolerations {
+			if toleration.Key == types.DedicatedNodeRoleLabel {
+				hasToleration = true
+				break
+			}
+		}
+
+		if hasToleration {
+			log.Debugf("[%s] skipping pod already has the required toleration", podKey)
+			incCounterSkipped(podKey)
+			skipped = true
+			return nil
+		}
+		toleration := corev1.Toleration{
+			Key:      types.DedicatedNodeRoleLabel,
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		}
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, toleration)
+
+		_, updateErr := clientset.CoreV1().Pods(pod.Namespace).Update(context.Background(), pod, metav1.UpdateOptions{})
+		if updateErr != nil {
+			log.Errorf("[%s] failed to update pod: %v", podKey, updateErr)
+		}
+		return updateErr
+	})
+
+	if retryErr != nil {
+		log.Errorf("[%s] failed to update pod: %v", podKey, retryErr)
+		incCounterFailure(podKey)
+	} else if !skipped {
+		log.Infof("[%s] successfully added toleration to pod", podKey)
+		incCounterSuccess(podKey)
+	}
+}

--- a/pkg/cmd/adm/e2ed/root.go
+++ b/pkg/cmd/adm/e2ed/root.go
@@ -11,6 +11,7 @@ func NewCommandE2eDedicated() *cobra.Command {
 		Short: "Administrative commands for e2e-dedicated node configuration",
 	}
 
+	cmd.AddCommand(newCmdE2eDedicatedController())
 	cmd.AddCommand(taintNodeCmd)
 
 	return cmd

--- a/pkg/cmd/adm/e2ed/taintNode.go
+++ b/pkg/cmd/adm/e2ed/taintNode.go
@@ -137,5 +137,4 @@ func taintNodeRun(cmd *cobra.Command, args []string) {
 	if err := applyTaintToNode(kclient, taintNodeArgs.nodeName); err != nil {
 		log.Fatalf("Failed to apply taint to node: %v", err)
 	}
-	log.Infof("Successfully applied taint to node %s", taintNodeArgs.nodeName)
 }

--- a/pkg/destroy/destroy.go
+++ b/pkg/destroy/destroy.go
@@ -44,20 +44,18 @@ func NewCmdDestroy() *cobra.Command {
 				return err
 			}
 
-			err = o.DeleteSonobuoyEnv(sclient)
-			if err != nil {
+			log.Info("removing opct namespace...")
+			if err := o.DeleteSonobuoyEnv(sclient); err != nil {
 				log.Warn(err)
 			}
 
-			log.Info("removing non-openshift NS...")
-			err = o.DeleteTestNamespaces(kclient)
-			if err != nil {
+			log.Info("removing stale e2e namespaces...")
+			if err := o.DeleteTestNamespaces(kclient); err != nil {
 				log.Warn(err)
 			}
 
 			log.Info("restoring privileged environment...")
-			err = o.RestoreSCC(kclient)
-			if err != nil {
+			if err := o.RestoreSCC(kclient); err != nil {
 				log.Warn(err)
 			}
 

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -19,10 +19,12 @@ const (
 	SonobuoyLabelComponentName     = "component"
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
+	ControllerImage                = "quay.io/opct/opct:v0.6.0-alpha.1"
 	PluginsImage                   = "plugin-openshift-tests:v0.5.2"
 	CollectorImage                 = "plugin-artifacts-collector:v0.5.2"
 	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.2"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
+	DedicatedControllerName        = "opct-dedicated-e2e-controller"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:

This change is proposing a controller to watch the e2e pods failed to schedule, mutating those to apply the OPCT  dedicated toleration, targeting to prevent false-positive failures in the conformance results due the dedicated node introduced as required by OPCT.

The controller is started by a command `adm e2e-dedicated controller`, distributed with the same image of `opct`. The deployment will be created in `opct` namespace when the command `run` is executed. The destroy flow will remove all resources in `opct` namespace, not requiring a dedicated logic to remove the controller deployment.

Rehearsal Tests: https://github.com/openshift/release/pull/62503

Done checklist:
- [x] Validate if the tests failed to schedule due dedicated node have been resolved
- [x] Validate CI job using this feature
- [x] Reproduce if bugs linked to the Epic* is related to dedicated node failure, and this solution would resolved it
    - This change resolves all e2e tests choosing randomly workers node. We've observing when the worker node selected to be the dedicated node is the first in the node list, there is more chance to fall into this issue. Although the command `e2e-dedicated taint-node` tries to select the "best node" by preventing scheduling in nodes with monitoring stack, preventing lack of resources while running the workflow. Considering we don't have control of how monitoring stack schedule (and we don't want to tied on this), and partners don't use this logic, the controller will resolve the problem more generically.
    - Here are examples of bugs reporting failures due dedicated node[1][2][3][4]. The Rehearsal jobs[5][6] also is example running a version with the dedicated controller with (shiny) improvement in the false-positives failures.
- [x] Collect the controller logs. https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/78

*Epic [OPCT-332](https://issues.redhat.com/browse/OPCT-332)

**Which issue(s) this PR fixes**:

Fixes/Closes issues: [1][2][3][4]

References:
- [1] https://issues.redhat.com/browse/OPCT-277
- [2] [OPCT-310](https://issues.redhat.com/browse/OPCT-310)
- [3] [OPCT-283](https://issues.redhat.com/browse/OPCT-283)
- [4] [OCPBUGS-31407](https://issues.redhat.com/browse/OCPBUGS-31407) (partially)
- [5] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-opct-external-aws-ccm/1898524710761664512/artifacts/opct-external-aws-ccm/opct-conformance-test-results/build-log.txt
- [6] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/62503/rehearse-62503-periodic-ci-openshift-release-master-nightly-4.17-opct-external-aws-ccm/1900206675432837120/artifacts/opct-external-aws-ccm/opct-conformance-test-results/artifacts/log-results.txt

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.
