### PR TITLE
OPCT-339: cleaner: enhance archive removing unused objects

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -218,7 +218,7 @@ jobs:
 
       - name: Preparing testdata
         env:
-          ARTIFACT: fake-cleaner.tar.gz
+          ARTIFACT: fake-cleaner-v2.tar.gz
           CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
           LOCAL_TEST_DATA: /tmp/artifact.tar.gz
         run: |
@@ -229,7 +229,7 @@ jobs:
           echo "> Setting exec permissions to OPCT:"
           chmod u+x ${CUSTOM_BUILD_PATH}
 
-      - name: "e2e parse metrics: opct adm cleaner"
+      - name: "e2e run: opct adm cleaner"
         env:
           CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
           LOCAL_TEST_DATA: /tmp/artifact.tar.gz
@@ -237,8 +237,36 @@ jobs:
           ${CUSTOM_BUILD_PATH} adm cleaner \
             --input ${LOCAL_TEST_DATA} \
             --output /tmp/redacted.tar.gz
+
           mkdir data
           tar xfz /tmp/redacted.tar.gz -C data
+
+      - name: "e2e run: opct adm cleaner: ensure JSONPatchRules"
+        env:
+          CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
+          LOCAL_TEST_DATA: /tmp/artifact.tar.gz
+        run: |
           # Prevent yaml-ci issues
           MCC=machineconfiguration.openshift.io_v1_controllerconfigs.json
-          jq .items[].spec.internalRegistryPullSecret data/resources/cluster/${MCC}
+          RES=$(jq .items[].spec.internalRegistryPullSecret data/resources/cluster/${MCC})
+          echo "RES=${RES}"
+          want="\"REDACTED\""
+          if [[ "${RES}" != "${want}" ]]; then
+            echo "Unexpected result"
+            echo "Got: ${RES}"
+            echo "Want: ${want}"
+          fi
+
+      - name: "e2e run: opct adm cleaner: ensure RemoveFilePatternRules"
+        env:
+          CUSTOM_BUILD_PATH: /tmp/build/opct-linux-amd64
+          LOCAL_TEST_DATA: /tmp/artifact.tar.gz
+        run: |
+          # Prevent yaml-ci issues
+          count=$(ls data/resources/ns/*/packages.operators.coreos.com_v1_packagemanifests.json | wc -l)
+          want=1
+          if [[ ${count} -ne ${want} ]]; then
+            echo "File cleaner left behind files: packages.operators.coreos.com_v1_packagemanifests.json"
+            echo "Got: ${count}"
+            echo "Want: ${want}"
+          fi

--- a/internal/cleaner/cleaner.go
+++ b/internal/cleaner/cleaner.go
@@ -6,24 +6,48 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	log "github.com/sirupsen/logrus"
+	"k8s.io/utils/ptr"
 )
 
-var patches = map[string]string{
-	"resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json": `[
-        {
-            "op": "replace",
-            "path": "/items/0/spec/internalRegistryPullSecret",
-            "value": "REDACTED"
-        }
-    ]`,
+type PatchRule struct {
+	JSONPatch    *string
+	RegexPattern *regexp.Regexp
+	KeepCount    uint64
+	Count        uint64
 }
 
-// ScanPatchTarGzipReaderFor scan for patches the artifact stream, returning
-// the cleaned artifact.
+var (
+	// JSONPatchRules is a map with the paths to files in the archive to apply RFC6902 JSON patches.
+	JSONPatchRules = map[string]*PatchRule{
+		"resources/cluster/machineconfiguration.openshift.io_v1_controllerconfigs.json": &PatchRule{
+			JSONPatch: ptr.To[string](`[
+					{
+						"op": "replace",
+						"path": "/items/0/spec/internalRegistryPullSecret",
+						"value": "REDACTED"
+					}
+				]`,
+			),
+		},
+	}
+
+	// RemoveFilePatternRules is a map with regular expressions to remove files in the result archive.
+	RemoveFilePatternRules = map[string]*PatchRule{
+		"packages.operators.coreos.com_v1_packagemanifests.json": &PatchRule{
+			RegexPattern: regexp.MustCompile("resources/ns/.*/packages.operators.coreos.com_v1_packagemanifests.json"),
+			// Keeping at least one object for auditing.
+			KeepCount: 1,
+			Count:     0,
+		},
+	}
+)
+
+// ScanPatchTarGzipReaderFor scans and patches the artifact stream, returning the cleaned artifact.
 func ScanPatchTarGzipReaderFor(r io.Reader) (resp io.Reader, size int, err error) {
 	log.Debug("Scanning the artifact for patches...")
 	size = 0
@@ -43,8 +67,7 @@ func ScanPatchTarGzipReaderFor(r io.Reader) (resp io.Reader, size int, err error
 	gzipWriter := gzip.NewWriter(&buf)
 	tarWriter := tar.NewWriter(gzipWriter)
 
-	// Find and process the desired file
-	var desiredFile []byte
+	// Process the tar headers
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -54,82 +77,8 @@ func ScanPatchTarGzipReaderFor(r io.Reader) (resp io.Reader, size int, err error
 			return nil, size, fmt.Errorf("unable to process file in archive: %w", err)
 		}
 
-		// Processing pre-defined patches, including recursively archives inside base.
-		if _, ok := patches[header.Name]; ok {
-			// Once the pre-defined/hardcoded patch matches with file stream, apply
-			// the path according to the extension. Currently only JSON patches
-			// are supported.
-			log.Debugf("Patch pattern matched for: %s", header.Name)
-			if strings.HasSuffix(header.Name, ".json") {
-				var patchedFile []byte
-				desiredFile, err = io.ReadAll(tarReader)
-				if err != nil {
-					log.Errorf("unable to read file in archive: %v", err)
-					return nil, size, fmt.Errorf("unable to read file in archive: %w", err)
-				}
-
-				// Apply JSON patch to the file
-				patchedFile, err = applyJSONPatch(header.Name, desiredFile)
-				if err != nil {
-					log.Errorf("unable to apply patch to file %s: %v", header.Name, err)
-					return nil, size, fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
-				}
-
-				// Update the file size in the header
-				header.Size = int64(len(patchedFile))
-				log.Debugf("Patched %d bytes", header.Size)
-
-				// Write the updated file to stream.
-				if err := tarWriter.WriteHeader(header); err != nil {
-					log.Errorf("unable to write file header to new archive: %v", err)
-					return nil, size, fmt.Errorf("unable to write file header to new archive: %w", err)
-				}
-				if _, err := tarWriter.Write(patchedFile); err != nil {
-					log.Errorf("unable to write file data to new archive: %v", err)
-					return nil, size, fmt.Errorf("unable to write file data to new archive: %w", err)
-				}
-			} else {
-				log.Debugf("unknown extension, skipping patch for file %s", header.Name)
-			}
-
-		} else if strings.HasSuffix(header.Name, ".tar.gz") {
-			// recursively scan for .tar.gz files rewriting it back to the original archive.
-			// by default sonobuoy writes a base archive, and the result(s) will be inside of
-			// the base. So it is required to recursively scan archives to find required, hardcoded,
-			// patches.
-			log.Debugf("Scanning tarball archive: %s", header.Name)
-			resp, size, err = ScanPatchTarGzipReaderFor(tarReader)
-			if err != nil {
-				return nil, size, fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
-			}
-
-			// Update the file size in the header
-			header.Size = int64(size)
-
-			// Write the updated header and file content
-			buf := new(bytes.Buffer)
-			_, err := io.Copy(buf, resp)
-			if err != nil {
-				return nil, size, err
-			}
-
-			// write archive back to stream.
-			if err := tarWriter.WriteHeader(header); err != nil {
-				log.Errorf("unable to write file header to new archive: %v", err)
-				return nil, size, fmt.Errorf("unable to write file header to new archive: %w", err)
-			}
-			if _, err := tarWriter.Write(buf.Bytes()); err != nil {
-				log.Errorf("unable to write file data to new archive: %v", err)
-				return nil, size, fmt.Errorf("unable to write file data to new archive: %w", err)
-			}
-		} else {
-			// Copy other files as-is
-			if err := tarWriter.WriteHeader(header); err != nil {
-				return nil, size, fmt.Errorf("error streaming file header to new archive: %w", err)
-			}
-			if _, err := io.Copy(tarWriter, tarReader); err != nil {
-				return nil, size, fmt.Errorf("error streaming file data to new archive: %w", err)
-			}
+		if err := processTarHeader(header, tarReader, tarWriter); err != nil {
+			return nil, size, err
 		}
 	}
 
@@ -146,9 +95,108 @@ func ScanPatchTarGzipReaderFor(r io.Reader) (resp io.Reader, size int, err error
 	return bytes.NewReader(buf.Bytes()), size, nil
 }
 
-// applyJSONPatch apply hard coded patches to stream, returning the cleaned file.
+// processTarHeader processes the tar header and applies patches or removes files as needed.
+func processTarHeader(header *tar.Header, tarReader *tar.Reader, tarWriter *tar.Writer) error {
+	// Processing pre-defined patches, including recursively archives inside base.
+	if _, ok := JSONPatchRules[header.Name]; ok {
+		// Once the pre-defined/hardcoded patch matches with file stream, apply
+		// the path according to the extension. Currently only JSON patches
+		// are supported.
+		log.Debugf("Patch pattern matched for: %s", header.Name)
+		if strings.HasSuffix(header.Name, ".json") {
+			var patchedFile []byte
+			desiredFile, err := io.ReadAll(tarReader)
+			if err != nil {
+				log.Errorf("Unable to read file in archive: %v", err)
+				return fmt.Errorf("unable to read file in archive: %w", err)
+			}
+			// Apply JSON patch to the file
+			patchedFile, err = applyJSONPatch(header.Name, desiredFile)
+			if err != nil {
+				log.Errorf("Unable to apply patch to file %s: %v", header.Name, err)
+				return fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
+			}
+
+			// Update the file size in the header
+			header.Size = int64(len(patchedFile))
+			log.Debugf("File %s size %d bytes", header.Name, header.Size)
+
+			// Write the updated file to stream.
+			if err := tarWriter.WriteHeader(header); err != nil {
+				log.Errorf("Unable to write file header to new archive: %v", err)
+				return fmt.Errorf("unable to write file header to new archive: %w", err)
+			}
+			if _, err := tarWriter.Write(patchedFile); err != nil {
+				log.Errorf("Unable to write file data to new archive: %v", err)
+				return fmt.Errorf("unable to write file data to new archive: %w", err)
+			}
+		} else {
+			log.Debugf("Unknown extension, skipping patch for file %s", header.Name)
+		}
+
+	} else if strings.HasSuffix(header.Name, ".tar.gz") {
+		// Recursively scan for .tar.gz files rewriting it back to the original archive.
+		// By default sonobuoy writes a base archive, and the result(s) will be inside of
+		// the base. So it is required to recursively scan archives to find required, hardcoded,
+		// patches.
+		log.Debugf("Scanning tarball archive: %s", header.Name)
+		resp, size, err := ScanPatchTarGzipReaderFor(tarReader)
+		if err != nil {
+			return fmt.Errorf("unable to apply patch to file %s: %w", header.Name, err)
+		}
+
+		// Update the file size in the header
+		header.Size = int64(size)
+
+		// Write the updated header and file content
+		buf := new(bytes.Buffer)
+		_, err = io.Copy(buf, resp)
+		if err != nil {
+			return err
+		}
+
+		// Write archive back to stream.
+		if err := tarWriter.WriteHeader(header); err != nil {
+			log.Errorf("Unable to write file header to new archive: %v", err)
+			return fmt.Errorf("unable to write file header to new archive: %w", err)
+		}
+		if _, err := tarWriter.Write(buf.Bytes()); err != nil {
+			log.Errorf("Unable to write file data to new archive: %v", err)
+			return fmt.Errorf("unable to write file data to new archive: %w", err)
+		}
+	} else {
+		skip := false
+		for _, rule := range RemoveFilePatternRules {
+			if rule.RegexPattern.MatchString(header.Name) {
+				if rule.Count >= rule.KeepCount {
+					log.Debugf("Skipping file %s due to matching pattern rules", header.Name)
+					skip = true
+					continue
+				}
+				rule.Count += 1
+			}
+		}
+		if skip {
+			return nil
+		}
+
+		// Do nothing: copy unmatched files as-is.
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return fmt.Errorf("error streaming file header to new archive: %w", err)
+		}
+		if _, err := io.Copy(tarWriter, tarReader); err != nil {
+			return fmt.Errorf("error streaming file data to new archive: %w", err)
+		}
+	}
+	return nil
+}
+
+// applyJSONPatch applies hardcoded patches to the stream, returning the cleaned file.
 func applyJSONPatch(filepath string, data []byte) ([]byte, error) {
-	patch, err := jsonpatch.DecodePatch([]byte(patches[filepath]))
+	if _, ok := JSONPatchRules[filepath]; !ok {
+		return nil, fmt.Errorf("no patch rule for file: %s", filepath)
+	}
+	patch, err := jsonpatch.DecodePatch([]byte(*JSONPatchRules[filepath].JSONPatch))
 	if err != nil {
 		return nil, fmt.Errorf("decoding patch: %w", err)
 	}

--- a/pkg/cmd/adm/cleaner.go
+++ b/pkg/cmd/adm/cleaner.go
@@ -29,14 +29,13 @@ func init() {
 }
 
 func cleanerRun(cmd *cobra.Command, args []string) {
-
 	if cleanerArgs.input == "" {
-		log.Error("missing argumet --input <archive.tar.gz>")
+		log.Error("missing argument --input <archive.tar.gz>")
 		os.Exit(1)
 	}
 
 	if cleanerArgs.output == "" {
-		log.Error("missing argumet --output <new-archive.tar.gz>")
+		log.Error("missing argument --output <new-archive.tar.gz>")
 		os.Exit(1)
 	}
 

--- a/pkg/cmd/adm/parsemetrics.go
+++ b/pkg/cmd/adm/parsemetrics.go
@@ -32,12 +32,12 @@ func init() {
 func parseMetricsRun(cmd *cobra.Command, args []string) {
 
 	if parseMetricsArgs.input == "" {
-		log.Error("missing argumet --input <metric archive file.tar.xz>")
+		log.Error("missing argument --input <metric archive file.tar.xz>")
 		os.Exit(1)
 	}
 
 	if parseMetricsArgs.output == "" {
-		log.Error("missing argumet --output <target directory to save parsed metrics>")
+		log.Error("missing argument --output <target directory to save parsed metrics>")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces:

- Enhance the cleaner scanner to remove unused files by patterns when collecting the results from the server - client-side phase.
- Remove the weight, and unused, namespaced files `/packages.operators.coreos.com_v1_packagemanifests.json`, objects collected by sonobuoy aggregator. One file will stayed in the archive just for conference. This action will reduce the final archive file to almost 1/3 (from ~160 MiB to ~60MiB)


**Which issue(s) this PR fixes** :

https://issues.redhat.com/browse/OPCT-339
https://issues.redhat.com/browse/OPCT-340


**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [x] This change includes e2e tests.
