### PR TITLE
NO-JIRA: documentation fixes in the changelog CD pipeline

### DIFF
--- a/docs/guides/cluster-validation/installation-review.md
+++ b/docs/guides/cluster-validation/installation-review.md
@@ -130,7 +130,7 @@ The command `opct adm parse-etcd-logs` reads the logs, aggregates the requests a
 
 `opct adm parse-etcd-logs` is the utility to help troubleshoot the slow requests in the cluster, and help make decisions like changing the flavor of the block device used by the control plane, increasing IOPS, changing the flavor of the instances, etc.
 
-See the command [`opct adm parse-etcd-logs`](./opct/adm/parse-etcd-logs.md) for more information.
+See the command [`opct adm parse-etcd-logs`](../../opct/adm/parse-etcd-logs.md) for more information.
 
 #### Mount /var/lib/etcd in separate disk <a name="components-etcd-mount"></a>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,9 @@ nav:
     - BYO Plugin: devel/byo-plugin.md
     #- Repositories: devel/repositories.md
     - Architectures: devel/arch-support.md
-    #- Changelog: devel/CHANGELOG.md
+  - Release Notes:
+    # TODO: Create release note file document with summary updates by release.
+    - CHANGELOG.md
 
 # ##########
 # Page setup


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes:
- Fix documentation builder in the CD pipeline introduced by https://github.com/redhat-openshift-ecosystem/opct/pull/156[1] when the changelog generator parser was crashing while attempting to extract the PR ID from the squashed commit name.
- Re-add the generated changelog markdown page to a new section
- Fix type in the CLI reference URL

[1] https://github.com/redhat-openshift-ecosystem/opct/actions/runs/13708777894

**Which issue(s) this PR fixes**:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.
- [x] Tested locally with `mkdocs serve`
