### PR TITLE
OPCT-342: fix matchExpressions to remove trailing commas

### DIFF
--- a/docs/guides/cluster-validation/index.md
+++ b/docs/guides/cluster-validation/index.md
@@ -173,8 +173,8 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-    - key: machineconfiguration.openshift.io/role,
-      operator: In,
+    - key: machineconfiguration.openshift.io/role
+      operator: In
       values: [worker,opct]
   nodeSelector:
     matchLabels:

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -307,8 +307,8 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-      - key: machineconfiguration.openshift.io/role,
-        operator: In,
+      - key: machineconfiguration.openshift.io/role
+        operator: In
         values: [worker,opct]
   nodeSelector:
     matchLabels:


### PR DESCRIPTION
**What this PR does / why we need it**:
Validation of the `opct` `machineconfigpool` has been failing.  It appears that this [change](https://github.com/openshift/machine-config-operator/commit/d260da67967aa3e30a50a2229c52059d49a6c360) revealed typos in https://github.com/redhat-openshift-ecosystem/opct/blob/9ddc26024dfbf3c0dba4dca305ecdac6cbe9d69f/pkg/run/run.go#L310-L311 related to trailing commas.  This change removes those commas.

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #
- OPCT-342

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [x] This change includes docs. 
- [ ] This change includes unit tests.
