### PR TITLE
OPCT-348: bump plugins for v0.6.0-alpha.1

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -20,9 +20,9 @@ const (
 	SonobuoyLabelComponentValue    = "sonobuoy"
 	DefaultToolsRepository         = "quay.io/opct"
 	ControllerImage                = "quay.io/opct/opct:v0.6.0-alpha.1"
-	PluginsImage                   = "plugin-openshift-tests:v0.5.2"
-	CollectorImage                 = "plugin-artifacts-collector:v0.5.2"
-	MustGatherMonitoringImage      = "must-gather-monitoring:v0.5.2"
+	PluginsImage                   = "plugin-openshift-tests:v0.6.0-alpha.1"
+	CollectorImage                 = "plugin-artifacts-collector:v0.6.0-alpha.1"
+	MustGatherMonitoringImage      = "must-gather-monitoring:v0.6.0-alpha.1"
 	OpenShiftTestsImage            = "image-registry.openshift-image-registry.svc:5000/openshift/tests"
 	DedicatedControllerName        = "opct-dedicated-e2e-controller"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump plugins to v0.6.0-alpha.1 version. Build pipeline is publishing the image https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/actions/runs/13864670936

**Which issue(s) this PR fixes** *(optional, use `fixes #<issue_number>(, fixes #<issue_number>, ...)` format, where issue_number might be a GitHub issue, or a Jira story*:
Fixes #

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
