### PR TITLE
OPCT-326: disable kube-burner fixing long-running v0.6

### DIFF
--- a/data/templates/plugins/openshift-artifacts-collector.yaml
+++ b/data/templates/plugins/openshift-artifacts-collector.yaml
@@ -37,7 +37,7 @@ spec:
     - name: IMAGE_OVERRIDE_MUST_GATHER
       value: "{{ .MustGatherMonitoringImage }}"
     - name: SKIP_KUBE_BURNER
-      value: "false"
+      value: "true"
     - name: ENV_NODE_NAME
       valueFrom:
         fieldRef:


### PR DESCRIPTION
**What this PR does / why we need it**:

Disable kube-burner in stable releases to prevent CI issues.

Kube-burner need to be tuned to prevent long-running jobs. See the following jobs increasing almost one hour waiting for the 1/3 kube-burner job: 
[ci/rehearse/periodic-ci-openshift-release-master-nightly-4.18-opct-external-aws-ccm](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63503/rehearse-63503-periodic-ci-openshift-release-master-nightly-4.18-opct-external-aws-ccm/1909362302688169984)
ci/rehearse/periodic-ci-openshift-release-master-nightly-4.18-opct-external-aws-ccm — Job failed.                     BaseSHA:8b7eee7e759de990b51d51bbfc811f0ec26c8916
[ci/rehearse/periodic-ci-redhat-openshift-ecosystem-opct-main-4.16-platform-external-vsphere-upgrade](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63503/rehearse-63503-periodic-ci-redhat-openshift-ecosystem-opct-main-4.16-platform-external-vsphere-upgrade/1909362302772056064)
ci/rehearse/periodic-ci-redhat-openshift-ecosystem-opct-main-4.16-platform-external-vsphere-upgrade — Job failed.                     BaseSHA:8b7eee7e759de990b51d51bbfc811f0ec26c8916
[ci/rehearse/periodic-ci-redhat-openshift-ecosystem-opct-main-4.18-platform-none-vsphere](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/63503/rehearse-63503-periodic-ci-redhat-openshift-ecosystem-opct-main-4.18-platform-none-vsphere/1909362302730113024)
ci/rehearse/periodic-ci-redhat-openshift-ecosystem-opct-main-4.18-platform-none-vsphere

related/past PRs:
- https://github.com/redhat-openshift-ecosystem/provider-certification-plugins/pull/67
- https://github.com/redhat-openshift-ecosystem/opct/pull/169

**Which issue(s) this PR fixes**
Fixes #

**Checklist**
- [ ] Subject and description added to both, commit and PR.
- [ ] Relevant issues have been referenced.
- [ ] This change includes docs. 
- [ ] This change includes unit tests.
