### PR TITLE
OPCT-478: fix: polling with backoff for aggregator in status

### DIFF
--- a/pkg/status/cmd.go
+++ b/pkg/status/cmd.go
@@ -41,9 +41,8 @@ func cmdStatusRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Wait for Sonobuoy to create
-	if err := wait.WaitForRequiredResources(o.kclient); err != nil {
-		log.WithError(err).Error("error waiting for sonobuoy pods to become ready")
+	if err := wait.WaitForAggregatorReady(cmd.Context(), o.kclient); err != nil {
+		log.WithError(err).Error("error waiting for sonobuoy aggregator to become ready")
 		return err
 	}
 

--- a/pkg/wait/util.go
+++ b/pkg/wait/util.go
@@ -70,16 +70,28 @@ func WaitForRequiredResources(kclient kubernetes.Interface) error {
 // WaitForAggregatorReady polls until the sonobuoy aggregator pod is Running/Ready.
 // Uses List (no watch/reflector) with exponential backoff for transient API errors.
 func WaitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interface) error {
-	ctx, cancel := context.WithTimeout(parentCtx, aggregatorReadyTimeout)
-	defer cancel()
-
 	backoff := wait.Backoff{
 		Duration: 2 * time.Second,
 		Factor:   2.0,
 		Cap:      30 * time.Second,
 		Steps:    30,
-		Jitter:   0.1,
 	}
+	return waitForAggregatorReady(parentCtx, kclient, backoff, aggregatorReadyTimeout)
+}
+
+// waitForAggregatorReady drives the polling loop directly instead of using
+// wait.ExponentialBackoffWithContext, which stops and returns ErrWaitTimeout as
+// soon as the first Cap-truncated sleep occurs (i.e. it treats reaching the cap
+// as exhaustion). That would end polling after ~30s here instead of honoring
+// the full timeout. Looping manually and bounding only on ctx.Done() avoids
+// that, while still reusing backoff.Step() for the growing sleep interval.
+//
+// It also distinguishes a canceled/expired parentCtx from the timeout applied
+// here, so callers get the real cancellation reason instead of a misleading
+// "aggregator not ready" timeout error.
+func waitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interface, backoff wait.Backoff, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(parentCtx, timeout)
+	defer cancel()
 
 	startedAt := time.Now()
 	var lastWarnAt time.Time
@@ -99,41 +111,42 @@ func WaitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interf
 		log.Warn(msg)
 	}
 
-	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+	for {
 		pods, err := kclient.CoreV1().Pods(pkg.CertificationNamespace).List(ctx, metav1.ListOptions{
 			LabelSelector: aggregatorLabelSelector,
 		})
-		if err != nil {
+		switch {
+		case err != nil:
 			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsBadRequest(err) {
-				return false, fmt.Errorf("listing sonobuoy aggregator pods: %w", err)
+				return fmt.Errorf("listing sonobuoy aggregator pods: %w", err)
 			}
 			warnIfDue("error listing sonobuoy aggregator pods, retrying", err)
-			return false, nil
-		}
-
-		if len(pods.Items) == 0 {
+		case len(pods.Items) == 0:
 			warnIfDue("sonobuoy aggregator pod not found yet, retrying", nil)
-			return false, nil
-		}
-
-		for i := range pods.Items {
-			pod := &pods.Items[i]
-			if pod.Status.Phase == v1.PodRunning && podIsReady(pod) {
-				return true, nil
+		default:
+			ready := false
+			for i := range pods.Items {
+				pod := &pods.Items[i]
+				if pod.Status.Phase == v1.PodRunning && podIsReady(pod) {
+					ready = true
+					break
+				}
 			}
+			if ready {
+				return nil
+			}
+			warnIfDue("sonobuoy aggregator pod is not ready yet, retrying", nil)
 		}
 
-		warnIfDue("sonobuoy aggregator pod is not ready yet, retrying", nil)
-		return false, nil
-	})
-	if err == nil {
-		return nil
+		select {
+		case <-ctx.Done():
+			if parentCtx.Err() != nil {
+				return fmt.Errorf("waiting for sonobuoy aggregator pod: %w", parentCtx.Err())
+			}
+			return fmt.Errorf("timeout waiting for sonobuoy aggregator pod to become ready after %s: %w", timeout, ctx.Err())
+		case <-time.After(backoff.Step()):
+		}
 	}
-
-	if wait.Interrupted(err) {
-		return fmt.Errorf("timeout waiting for sonobuoy aggregator pod to become ready after %s: %w", aggregatorReadyTimeout, err)
-	}
-	return err
 }
 
 func podIsReady(pod *v1.Pod) bool {

--- a/pkg/wait/util.go
+++ b/pkg/wait/util.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -103,6 +104,9 @@ func WaitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interf
 			LabelSelector: aggregatorLabelSelector,
 		})
 		if err != nil {
+			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsBadRequest(err) {
+				return false, fmt.Errorf("listing sonobuoy aggregator pods: %w", err)
+			}
 			warnIfDue("error listing sonobuoy aggregator pods, retrying", err)
 			return false, nil
 		}
@@ -126,7 +130,7 @@ func WaitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interf
 		return nil
 	}
 
-	if errors.Is(err, wait.ErrWaitTimeout) || errors.Is(err, context.DeadlineExceeded) {
+	if wait.Interrupted(err) {
 		return fmt.Errorf("timeout waiting for sonobuoy aggregator pod to become ready after %s: %w", aggregatorReadyTimeout, err)
 	}
 	return err

--- a/pkg/wait/util.go
+++ b/pkg/wait/util.go
@@ -6,15 +6,23 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
 
 	"github.com/redhat-openshift-ecosystem/opct/pkg"
+)
+
+const (
+	aggregatorLabelSelector = "component=sonobuoy,sonobuoy-component=aggregator"
+	aggregatorReadyTimeout  = 3 * time.Minute
+	retryLogInterval        = 30 * time.Second
 )
 
 // WaitForRequiredResources will wait for the sonobuoy pod in the sonobuoy namespace to go into
@@ -25,10 +33,10 @@ func WaitForRequiredResources(kclient kubernetes.Interface) error {
 	restClient := kclient.CoreV1().RESTClient()
 
 	lw := cache.NewFilteredListWatchFromClient(restClient, "pods", pkg.CertificationNamespace, func(options *metav1.ListOptions) {
-		options.LabelSelector = "component=sonobuoy,sonobuoy-component=aggregator"
+		options.LabelSelector = aggregatorLabelSelector
 	})
 
-	// Wait for Sonobuoy Pods to become Ready
+	// Wait for Sonobuoy aggregator pod to become Ready
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Minute*10)
 	defer cancel()
 	_, err := watchtools.UntilWithSync(ctx, lw, obj, nil, func(event watch.Event) (bool, error) {
@@ -56,6 +64,72 @@ func WaitForRequiredResources(kclient kubernetes.Interface) error {
 	}
 
 	return nil
+}
+
+// WaitForAggregatorReady polls until the sonobuoy aggregator pod is Running/Ready.
+// Uses List (no watch/reflector) with exponential backoff for transient API errors.
+func WaitForAggregatorReady(parentCtx context.Context, kclient kubernetes.Interface) error {
+	ctx, cancel := context.WithTimeout(parentCtx, aggregatorReadyTimeout)
+	defer cancel()
+
+	backoff := wait.Backoff{
+		Duration: 2 * time.Second,
+		Factor:   2.0,
+		Cap:      30 * time.Second,
+		Steps:    30,
+		Jitter:   0.1,
+	}
+
+	startedAt := time.Now()
+	var lastWarnAt time.Time
+	warnIfDue := func(msg string, err error) {
+		now := time.Now()
+		if now.Sub(startedAt) < retryLogInterval {
+			return
+		}
+		if !lastWarnAt.IsZero() && now.Sub(lastWarnAt) < retryLogInterval {
+			return
+		}
+		lastWarnAt = now
+		if err != nil {
+			log.WithError(err).Warn(msg)
+			return
+		}
+		log.Warn(msg)
+	}
+
+	err := wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		pods, err := kclient.CoreV1().Pods(pkg.CertificationNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: aggregatorLabelSelector,
+		})
+		if err != nil {
+			warnIfDue("error listing sonobuoy aggregator pods, retrying", err)
+			return false, nil
+		}
+
+		if len(pods.Items) == 0 {
+			warnIfDue("sonobuoy aggregator pod not found yet, retrying", nil)
+			return false, nil
+		}
+
+		for i := range pods.Items {
+			pod := &pods.Items[i]
+			if pod.Status.Phase == v1.PodRunning && podIsReady(pod) {
+				return true, nil
+			}
+		}
+
+		warnIfDue("sonobuoy aggregator pod is not ready yet, retrying", nil)
+		return false, nil
+	})
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, wait.ErrWaitTimeout) || errors.Is(err, context.DeadlineExceeded) {
+		return fmt.Errorf("timeout waiting for sonobuoy aggregator pod to become ready after %s: %w", aggregatorReadyTimeout, err)
+	}
+	return err
 }
 
 func podIsReady(pod *v1.Pod) bool {

--- a/pkg/wait/util_test.go
+++ b/pkg/wait/util_test.go
@@ -7,9 +7,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/fake"
+	ktesting "k8s.io/client-go/testing"
 
 	"github.com/redhat-openshift-ecosystem/opct/pkg"
 )
@@ -58,8 +62,8 @@ func TestWaitForAggregatorReady_noPodsTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, utilwait.ErrWaitTimeout) {
-		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline or wait timeout", err)
+	if !utilwait.Interrupted(err) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want interrupted or deadline exceeded", err)
 	}
 }
 
@@ -73,7 +77,22 @@ func TestWaitForAggregatorReady_pendingTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, utilwait.ErrWaitTimeout) {
-		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline or wait timeout", err)
+	if !utilwait.Interrupted(err) && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want interrupted or deadline exceeded", err)
+	}
+}
+
+func TestWaitForAggregatorReady_forbidden(t *testing.T) {
+	kclient := fake.NewSimpleClientset()
+	kclient.PrependReactor("list", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", errors.New("denied"))
+	})
+
+	err := WaitForAggregatorReady(context.Background(), kclient)
+	if err == nil {
+		t.Fatal("WaitForAggregatorReady() error = nil, want forbidden error")
+	}
+	if !apierrors.IsForbidden(err) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want forbidden error", err)
 	}
 }

--- a/pkg/wait/util_test.go
+++ b/pkg/wait/util_test.go
@@ -3,6 +3,7 @@ package wait
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,8 +25,8 @@ func readyAggregatorPod(name string) *v1.Pod {
 			Name:      name,
 			Namespace: pkg.CertificationNamespace,
 			Labels: map[string]string{
-				"component":           "sonobuoy",
-				"sonobuoy-component":  "aggregator",
+				"component":          "sonobuoy",
+				"sonobuoy-component": "aggregator",
 			},
 		},
 		Status: v1.PodStatus{
@@ -62,8 +63,8 @@ func TestWaitForAggregatorReady_noPodsTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
 	}
-	if !utilwait.Interrupted(err) && !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("WaitForAggregatorReady() error = %v, want interrupted or deadline exceeded", err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline exceeded", err)
 	}
 }
 
@@ -77,8 +78,8 @@ func TestWaitForAggregatorReady_pendingTimesOut(t *testing.T) {
 	if err == nil {
 		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
 	}
-	if !utilwait.Interrupted(err) && !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("WaitForAggregatorReady() error = %v, want interrupted or deadline exceeded", err)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline exceeded", err)
 	}
 }
 
@@ -94,5 +95,62 @@ func TestWaitForAggregatorReady_forbidden(t *testing.T) {
 	}
 	if !apierrors.IsForbidden(err) {
 		t.Fatalf("WaitForAggregatorReady() error = %v, want forbidden error", err)
+	}
+}
+
+// TestWaitForAggregatorReady_parentCancellation ensures a canceled parent
+// context is reported as the real cancellation, not mislabeled as the
+// aggregator readiness timeout applied internally.
+func TestWaitForAggregatorReady_parentCancellation(t *testing.T) {
+	kclient := fake.NewSimpleClientset(pendingAggregatorPod("sonobuoy-aggregator"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	err := WaitForAggregatorReady(ctx, kclient)
+	if err == nil {
+		t.Fatal("WaitForAggregatorReady() error = nil, want cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want context.Canceled", err)
+	}
+	if strings.Contains(err.Error(), "timeout waiting for sonobuoy aggregator pod to become ready after") {
+		t.Fatalf("WaitForAggregatorReady() error = %v, parent cancellation must not be reported as an aggregator readiness timeout", err)
+	}
+}
+
+// TestWaitForAggregatorReady_pollsUntilConfiguredTimeout ensures polling
+// continues for the full configured timeout instead of stopping early once
+// the backoff delay first hits its Cap (a quirk of
+// wait.ExponentialBackoffWithContext, which treats a Cap-truncated sleep as
+// exhaustion). A fake reactor only reports the pod ready after more List
+// calls than the backoff's growth phase (Duration->Cap) would allow.
+func TestWaitForAggregatorReady_pollsUntilConfiguredTimeout(t *testing.T) {
+	kclient := fake.NewSimpleClientset()
+
+	const callsBeforeReady = 5
+	calls := 0
+	kclient.PrependReactor("list", "pods", func(action ktesting.Action) (bool, runtime.Object, error) {
+		calls++
+		pod := pendingAggregatorPod("sonobuoy-aggregator")
+		if calls >= callsBeforeReady {
+			pod = readyAggregatorPod("sonobuoy-aggregator")
+		}
+		return true, &v1.PodList{Items: []v1.Pod{*pod}}, nil
+	})
+
+	// Duration grows past Cap after 3 steps (5ms, 10ms, 20ms), which would
+	// exhaust wait.ExponentialBackoffWithContext well before callsBeforeReady
+	// is reached. A generous timeout proves polling continues past that point.
+	backoff := utilwait.Backoff{Duration: 5 * time.Millisecond, Factor: 2, Cap: 20 * time.Millisecond, Steps: 10}
+	err := waitForAggregatorReady(context.Background(), kclient, backoff, time.Second)
+	if err != nil {
+		t.Fatalf("waitForAggregatorReady() error = %v, want nil once the pod becomes ready", err)
+	}
+	if calls < callsBeforeReady {
+		t.Fatalf("expected at least %d list calls to exercise the cap-exhaustion path, got %d", callsBeforeReady, calls)
 	}
 }

--- a/pkg/wait/util_test.go
+++ b/pkg/wait/util_test.go
@@ -1,0 +1,79 @@
+package wait
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilwait "k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/redhat-openshift-ecosystem/opct/pkg"
+)
+
+func readyAggregatorPod(name string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: pkg.CertificationNamespace,
+			Labels: map[string]string{
+				"component":           "sonobuoy",
+				"sonobuoy-component":  "aggregator",
+			},
+		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+			Conditions: []v1.PodCondition{
+				{Type: v1.PodReady, Status: v1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func pendingAggregatorPod(name string) *v1.Pod {
+	pod := readyAggregatorPod(name)
+	pod.Status.Phase = v1.PodPending
+	pod.Status.Conditions = nil
+	return pod
+}
+
+func TestWaitForAggregatorReady_ready(t *testing.T) {
+	kclient := fake.NewSimpleClientset(readyAggregatorPod("sonobuoy-aggregator"))
+
+	if err := WaitForAggregatorReady(context.Background(), kclient); err != nil {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want nil", err)
+	}
+}
+
+func TestWaitForAggregatorReady_noPodsTimesOut(t *testing.T) {
+	kclient := fake.NewSimpleClientset()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	err := WaitForAggregatorReady(ctx, kclient)
+	if err == nil {
+		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, utilwait.ErrWaitTimeout) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline or wait timeout", err)
+	}
+}
+
+func TestWaitForAggregatorReady_pendingTimesOut(t *testing.T) {
+	kclient := fake.NewSimpleClientset(pendingAggregatorPod("sonobuoy-aggregator"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	err := WaitForAggregatorReady(ctx, kclient)
+	if err == nil {
+		t.Fatal("WaitForAggregatorReady() error = nil, want timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, utilwait.ErrWaitTimeout) {
+		t.Fatalf("WaitForAggregatorReady() error = %v, want deadline or wait timeout", err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**

Replace the watch-based `WaitForRequiredResources` call in `opct status`
with `WaitForAggregatorReady`, which polls the aggregator pod using List
requests and exponential backoff to handle transient API errors.
Three correctness fixes are included:

- **Premature timeout** — `wait.ExponentialBackoffWithContext` exits
  early once the backoff delay first hits its Cap (it resets `Steps` to
  0 at that point, ending the `for Steps > 0` loop). With the configured
  values the effective retry window was ~30s, not the intended 3 minutes.
  The poll loop is now driven by `ctx.Done()` directly; `backoff.Step()`
  is used only as a delay source, so the full timeout is always honoured.

- **Parent cancellation mislabeled** — any interruption matched by
  `wait.Interrupted` was wrapped as `"timeout waiting … after 3m0s"`,
  including a caller-initiated `context.Canceled`. The error message now
  reflects the actual cause.

- **Non-retryable API errors** — `Forbidden`, `Unauthorized`, and
  `BadRequest` responses from the pod List are returned immediately
  instead of silently retrying until timeout.

**Which issue(s) this PR fixes**
Relates to OPCT-478

**Checklist**
- [x] Subject and description added to both, commit and PR.
- [x] Relevant issues have been referenced.
- [ ] This change includes docs.
- [x] This change includes unit tests.